### PR TITLE
expose version release notes via MCP get_version_release_notes tool

### DIFF
--- a/dify-helm-watchdog/package.json
+++ b/dify-helm-watchdog/package.json
@@ -34,6 +34,7 @@
     "swagger-ui-react": "^5.30.2",
     "tailwind-merge": "^3.3.1",
     "tar-stream": "3.1.7",
+    "turndown": "^7.2.4",
     "yaml": "2.8.1"
   },
   "devDependencies": {
@@ -46,6 +47,7 @@
     "@types/semver": "^7.7.1",
     "@types/swagger-ui-react": "^5.18.0",
     "@types/tar-stream": "3.1.4",
+    "@types/turndown": "^5.0.6",
     "code-inspector-plugin": "^1.2.10",
     "eslint": "^9",
     "eslint-config-next": "15.5.6",

--- a/dify-helm-watchdog/src/app/api/v1/releases/[version]/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/releases/[version]/route.ts
@@ -1,79 +1,7 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
+import { sanitizeEeReleaseHtml } from "@/lib/release-notes";
 
 export const runtime = "nodejs";
-
-const TARGET_CLASS =
-  'w-[960px] max-w-full mx-auto px-5 py-2xl flex flex-col gap-2xl';
-
-/**
- * Extract the target div (and its children) from raw HTML using nested-tag
- * counting so that inner `<div>` elements don't break the extraction.
- */
-function extractTargetDiv(html: string): string | null {
-  const needle = `class="${TARGET_CLASS}"`;
-  const classIdx = html.indexOf(needle);
-  if (classIdx === -1) return null;
-
-  // Walk backwards to find the opening `<div`
-  const openTag = html.lastIndexOf("<div", classIdx);
-  if (openTag === -1) return null;
-
-  // Walk forward counting open/close div tags
-  let depth = 0;
-  const divOpen = /<div[\s>]/gi;
-  const divClose = /<\/div\s*>/gi;
-
-  // Merge open and close positions into a sorted list
-  type TagHit = { pos: number; isOpen: boolean };
-  const hits: TagHit[] = [];
-
-  divOpen.lastIndex = openTag;
-  let m: RegExpExecArray | null;
-  while ((m = divOpen.exec(html)) !== null) {
-    hits.push({ pos: m.index, isOpen: true });
-  }
-  divClose.lastIndex = openTag;
-  while ((m = divClose.exec(html)) !== null) {
-    hits.push({ pos: m.index, isOpen: false });
-  }
-  hits.sort((a, b) => a.pos - b.pos);
-
-  for (const hit of hits) {
-    depth += hit.isOpen ? 1 : -1;
-    if (depth === 0) {
-      // Find the `>` that closes `</div>`
-      const end = html.indexOf(">", hit.pos) + 1;
-      return html.slice(openTag, end);
-    }
-  }
-
-  return null;
-}
-
-/**
- * Strip script tags from HTML for safety.
- */
-function stripScripts(html: string): string {
-  return html.replace(/<script[\s\S]*?<\/script\s*>/gi, "");
-}
-
-const EE_ORIGIN = "https://ee.dify.ai";
-
-/**
- * Rewrite relative hrefs and srcs to absolute ee.dify.ai URLs
- * and open them in a new tab.
- */
-function rewriteLinks(html: string): string {
-  return html.replace(
-    /(<a\s[^>]*?)href="(\/[^"]*)"([^>]*>)/gi,
-    (_match, before: string, path: string, after: string) =>
-      `${before}href="${EE_ORIGIN}${path}" target="_blank" rel="noopener noreferrer"${after}`,
-  ).replace(
-    /(<img\s[^>]*?)src="(\/[^"]*)"([^>]*>)/gi,
-    (_match, before: string, path: string, after: string) =>
-      `${before}src="${EE_ORIGIN}${path}"${after}`,
-  );
-}
 
 /**
  * @swagger
@@ -132,9 +60,9 @@ export async function GET(
     }
 
     const html = await res.text();
-    const extracted = extractTargetDiv(html);
+    const sanitised = sanitizeEeReleaseHtml(html);
 
-    if (!extracted) {
+    if (!sanitised) {
       return createErrorResponse({
         request,
         status: 502,
@@ -142,8 +70,6 @@ export async function GET(
         statusText: "UNAVAILABLE",
       });
     }
-
-    const sanitised = rewriteLinks(stripScripts(extracted));
 
     return createJsonResponse(
       { version, html: sanitised },

--- a/dify-helm-watchdog/src/lib/mcp/tools.ts
+++ b/dify-helm-watchdog/src/lib/mcp/tools.ts
@@ -4,6 +4,10 @@
  */
 
 import { loadCache } from "@/lib/helm";
+import {
+  ReleaseNotesError,
+  fetchReleaseNotesAsMarkdown,
+} from "@/lib/release-notes";
 import type { ImageValidationRecord, StoredVersion } from "@/lib/types";
 import { countValidationStatuses, normalizeValidationPayload } from "@/lib/validation";
 import YAML from "yaml";
@@ -69,6 +73,21 @@ export const TOOLS: McpToolDefinition[] = [
           type: "boolean",
           description:
             "When true, includes validation status and variant information for each image.",
+        },
+      },
+      required: ["version"],
+    },
+  },
+  {
+    name: "get_version_release_notes",
+    description:
+      "Returns the release notes (Details tab content) for a specific Helm chart version as Markdown. For versions >= 3.9.0 the content comes from ee.dify.ai (HTML converted to Markdown); for older versions it comes from the Dify Helm docs site (native Markdown, normalised).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        version: {
+          type: "string",
+          description: "The chart version to fetch release notes for (e.g., '3.9.0' or '1.5.0').",
         },
       },
       required: ["version"],
@@ -404,6 +423,27 @@ const validateImages = async (
   return jsonResult(validationData);
 };
 
+const getVersionReleaseNotes = async (
+  args: Record<string, unknown>,
+): Promise<McpToolResult> => {
+  const version = String(args.version ?? "");
+  if (!version) {
+    return errorResult("Missing required parameter: version");
+  }
+
+  try {
+    const notes = await fetchReleaseNotesAsMarkdown(version);
+    return jsonResult(notes);
+  } catch (error) {
+    if (error instanceof ReleaseNotesError) {
+      return errorResult(error.message);
+    }
+    return errorResult(
+      `Failed to fetch release notes for v${version}: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+};
+
 // Tool executor
 export const executeTool = async (
   name: string,
@@ -420,6 +460,8 @@ export const executeTool = async (
       return listImages(args);
     case "validate_images":
       return validateImages(args);
+    case "get_version_release_notes":
+      return getVersionReleaseNotes(args);
     default:
       return errorResult(`Unknown tool: ${name}`);
   }

--- a/dify-helm-watchdog/src/lib/release-notes.ts
+++ b/dify-helm-watchdog/src/lib/release-notes.ts
@@ -1,0 +1,193 @@
+import semver from "semver";
+import TurndownService from "turndown";
+
+const EE_ORIGIN = "https://ee.dify.ai";
+const DOCS_BASE_URL = "https://langgenius.github.io/dify-helm/";
+const DOCS_PAGE_BASE = `${DOCS_BASE_URL}pages/`;
+const EE_THRESHOLD = "3.9.0";
+const TARGET_CLASS =
+  'w-[960px] max-w-full mx-auto px-5 py-2xl flex flex-col gap-2xl';
+
+const extractTargetDiv = (html: string): string | null => {
+  const needle = `class="${TARGET_CLASS}"`;
+  const classIdx = html.indexOf(needle);
+  if (classIdx === -1) return null;
+
+  const openTag = html.lastIndexOf("<div", classIdx);
+  if (openTag === -1) return null;
+
+  let depth = 0;
+  const divOpen = /<div[\s>]/gi;
+  const divClose = /<\/div\s*>/gi;
+
+  type TagHit = { pos: number; isOpen: boolean };
+  const hits: TagHit[] = [];
+
+  divOpen.lastIndex = openTag;
+  let m: RegExpExecArray | null;
+  while ((m = divOpen.exec(html)) !== null) {
+    hits.push({ pos: m.index, isOpen: true });
+  }
+  divClose.lastIndex = openTag;
+  while ((m = divClose.exec(html)) !== null) {
+    hits.push({ pos: m.index, isOpen: false });
+  }
+  hits.sort((a, b) => a.pos - b.pos);
+
+  for (const hit of hits) {
+    depth += hit.isOpen ? 1 : -1;
+    if (depth === 0) {
+      const end = html.indexOf(">", hit.pos) + 1;
+      return html.slice(openTag, end);
+    }
+  }
+
+  return null;
+};
+
+const stripScripts = (html: string): string =>
+  html.replace(/<script[\s\S]*?<\/script\s*>/gi, "");
+
+const rewriteEeLinks = (html: string): string =>
+  html
+    .replace(
+      /(<a\s[^>]*?)href="(\/[^"]*)"([^>]*>)/gi,
+      (_match, before: string, path: string, after: string) =>
+        `${before}href="${EE_ORIGIN}${path}" target="_blank" rel="noopener noreferrer"${after}`,
+    )
+    .replace(
+      /(<img\s[^>]*?)src="(\/[^"]*)"([^>]*>)/gi,
+      (_match, before: string, path: string, after: string) =>
+        `${before}src="${EE_ORIGIN}${path}"${after}`,
+    );
+
+export const sanitizeEeReleaseHtml = (rawHtml: string): string | null => {
+  const extracted = extractTargetDiv(rawHtml);
+  if (!extracted) return null;
+  return rewriteEeLinks(stripScripts(extracted));
+};
+
+const resolveDocsUrl = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  try {
+    return new URL(trimmed, DOCS_PAGE_BASE).href;
+  } catch {
+    return trimmed;
+  }
+};
+
+const normalizeDocsMarkdown = (content: string): string =>
+  content
+    .replace(
+      /<a\s+[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi,
+      (_match, rawHref: string, label: string) =>
+        `[${label}](${resolveDocsUrl(rawHref)})`,
+    )
+    .replace(/<img\s+[^>]*>/gi, (match) => {
+      const srcMatch = match.match(/src=["']([^"']+)["']/i);
+      if (!srcMatch) return match;
+      const altMatch = match.match(/alt=["']([^"']*?)["']/i);
+      return `![${altMatch?.[1] ?? ""}](${resolveDocsUrl(srcMatch[1])})`;
+    })
+    .replace(
+      /!\[([^\]]*)\]\(([^)]+)\)/g,
+      (_match, alt: string, rawSrc: string) =>
+        `![${alt}](${resolveDocsUrl(rawSrc)})`,
+    );
+
+let turndownInstance: TurndownService | null = null;
+const getTurndown = (): TurndownService => {
+  if (!turndownInstance) {
+    turndownInstance = new TurndownService({
+      headingStyle: "atx",
+      codeBlockStyle: "fenced",
+      bulletListMarker: "-",
+    });
+  }
+  return turndownInstance;
+};
+
+export type ReleaseNotesSource = "ee" | "docs";
+
+export interface ReleaseNotesResult {
+  version: string;
+  source: ReleaseNotesSource;
+  sourceUrl: string;
+  content: string;
+}
+
+export class ReleaseNotesError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ReleaseNotesError";
+    this.status = status;
+  }
+}
+
+export const isEeVersion = (version: string): boolean =>
+  semver.valid(version) !== null && semver.gte(version, EE_THRESHOLD);
+
+export const fetchReleaseNotesAsMarkdown = async (
+  version: string,
+): Promise<ReleaseNotesResult> => {
+  if (!/^\d+\.\d+\.\d+/.test(version)) {
+    throw new ReleaseNotesError(
+      `Invalid version format: ${version}`,
+      400,
+    );
+  }
+
+  const headers = { "User-Agent": "dify-helm-watchdog/1.0" };
+
+  if (isEeVersion(version)) {
+    const sourceUrl = `${EE_ORIGIN}/releases/v${version}`;
+    const res = await fetch(sourceUrl, {
+      headers,
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) {
+      throw new ReleaseNotesError(
+        `Upstream returned HTTP ${res.status}`,
+        502,
+      );
+    }
+    const html = await res.text();
+    const sanitised = sanitizeEeReleaseHtml(html);
+    if (!sanitised) {
+      throw new ReleaseNotesError(
+        "Could not locate release notes content on upstream page",
+        502,
+      );
+    }
+    const markdown = getTurndown().turndown(sanitised);
+    return {
+      version,
+      source: "ee",
+      sourceUrl,
+      content: markdown,
+    };
+  }
+
+  const docsVersion = version.replace(/\./g, "_");
+  const sourceUrl = `${DOCS_PAGE_BASE}${docsVersion}.md`;
+  const res = await fetch(sourceUrl, {
+    headers,
+    next: { revalidate: 3600 },
+  });
+  if (!res.ok) {
+    throw new ReleaseNotesError(
+      `Upstream returned HTTP ${res.status}`,
+      res.status === 404 ? 404 : 502,
+    );
+  }
+  const raw = await res.text();
+  const normalised = normalizeDocsMarkdown(raw);
+  return {
+    version,
+    source: "docs",
+    sourceUrl,
+    content: normalised,
+  };
+};

--- a/dify-helm-watchdog/yarn.lock
+++ b/dify-helm-watchdog/yarn.lock
@@ -1340,6 +1340,11 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@mixmark-io/domino@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
+  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
+
 "@modelcontextprotocol/sdk@^1.17.2":
   version "1.20.2"
   resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.20.2.tgz#7c448a073164841814d34ec9c76bcc37f2d6ffdc"
@@ -2477,6 +2482,11 @@
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
+"@types/turndown@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@types/turndown/-/turndown-5.0.6.tgz#42a27397298a312d6088f29c0ff4819c518c1ecb"
+  integrity sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==
 
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
@@ -8682,6 +8692,13 @@ tsx@^4.19.2:
     get-tsconfig "^4.7.5"
   optionalDependencies:
     fsevents "~2.3.3"
+
+turndown@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.4.tgz#42d98202aefa8c188c997b586bc6da78bdf27ea2"
+  integrity sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==
+  dependencies:
+    "@mixmark-io/domino" "^2.2.0"
 
 tw-animate-css@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Adds MCP tool that returns release notes as Markdown for both EE (>=3.9.0, via ee.dify.ai + turndown) and older versions (docs.github.io).