### PR TITLE
feat: public /dashboard backed by Cloudflare Analytics Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# wrangler (cloudflare workers local cache)
+.wrangler/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/cloudflare/analytics-worker/README.md
+++ b/cloudflare/analytics-worker/README.md
@@ -1,0 +1,74 @@
+# analytics-worker
+
+Cloudflare Worker that ingests analytics events for `dify-helm-watchdog` and
+exposes a query endpoint for the public `/dashboard` page on the Vercel app.
+
+Wire-up: Vercel middleware / MCP handler → `POST /track` → Analytics Engine.
+Dashboard read: Vercel route → `POST /query` → SQL API → Analytics Engine.
+Browser never talks to this Worker directly.
+
+## What exists in Cloudflare (as of first deploy)
+
+| Resource | Identifier | Where to find it |
+|---|---|---|
+| CF account | `LangGenius OPC 环境` (`8f7d374db5cb1f025b7f71e28b84c9bb`) | dash.cloudflare.com (account switcher) |
+| Worker | `dify-watchdog-analytics` | Workers & Pages → Overview |
+| Custom domain | `dify-watchdog-analytics.langgenius.app` | Worker → Settings → Domains & Routes (DNS auto-created in `langgenius.app` zone) |
+| Analytics Engine dataset | `dify_watchdog_events` | bound as `env.EVENTS` (writes); reads via SQL API |
+| Worker secret | `ANALYTICS_WORKER_SECRET` | HMAC shared with Vercel — must match `ANALYTICS_WORKER_SECRET` in Vercel env |
+| Worker secret | `CF_ACCOUNT_ID` | same value as the account ID above, used by `/query` against the SQL API |
+| Worker secret | `CF_ANALYTICS_TOKEN` | API token, name `dify-watchdog-analytics-engine-read`, scope `Account Analytics:Read` on the LangGenius OPC account |
+| CF API token | `dify-watchdog-analytics-engine-read` | User → My Profile → API Tokens |
+
+Vercel side (project `dify-helm-watchdog`):
+
+| Env var | Where set | Notes |
+|---|---|---|
+| `ANALYTICS_WORKER_URL` | Production (+ Preview after merge if needed) | `https://dify-watchdog-analytics.langgenius.app` |
+| `ANALYTICS_WORKER_SECRET` | Production | must equal the Worker secret of the same name |
+| `ANALYTICS_SESSION_SALT` | Production | random hex, salts `sha256(ip + ua + salt)` to derive session ID; rotating invalidates uniqueness continuity |
+
+## Deploy / update
+
+```bash
+cd cloudflare/analytics-worker
+
+# one-time: log in (skip if already authenticated to LangGenius OPC)
+# unset CF_API_TOKEN CLOUDFLARE_API_TOKEN   # if a User Token from another account is exported in your shell
+# wrangler login
+
+wrangler deploy
+```
+
+To rotate a Worker secret:
+
+```bash
+wrangler secret put ANALYTICS_WORKER_SECRET   # paste new value
+# remember to update the Vercel side too, otherwise HMAC verification fails
+```
+
+## Tail / debug
+
+```bash
+wrangler tail                # live event stream
+wrangler secret list         # names only, no values
+```
+
+The Worker only accepts POST. A `curl https://dify-watchdog-analytics.langgenius.app/`
+returning `405 Method Not Allowed` is the healthy idle response.
+
+## Full teardown (in this order)
+
+1. **Vercel env vars** — remove `ANALYTICS_WORKER_URL`, `ANALYTICS_WORKER_SECRET`,
+   `ANALYTICS_SESSION_SALT` from Production (and Preview if you added them).
+   With those unset, tracking becomes a no-op and the `/dashboard` page renders
+   empty stats; the rest of the site is unaffected.
+2. **CF API token** — dashboard → My Profile → API Tokens → revoke
+   `dify-watchdog-analytics-engine-read`.
+3. **Worker** — `wrangler delete` from this directory. This removes the
+   `dify-watchdog-analytics.langgenius.app` DNS record (custom domain) and the
+   Worker itself. Worker secrets are deleted along with the Worker.
+4. **Analytics Engine dataset** — there is no manual delete for Analytics Engine
+   row data; the free-tier 90-day retention will age it out. Just stop writing.
+   The dataset binding name is `dify_watchdog_events` and lives only in this
+   `wrangler.toml`, so removing the Worker effectively orphans it.

--- a/cloudflare/analytics-worker/package.json
+++ b/cloudflare/analytics-worker/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dify-watchdog-analytics-worker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250101.0",
+    "typescript": "^5",
+    "wrangler": "^3.99.0"
+  }
+}

--- a/cloudflare/analytics-worker/src/index.ts
+++ b/cloudflare/analytics-worker/src/index.ts
@@ -1,0 +1,275 @@
+interface Env {
+  EVENTS: AnalyticsEngineDataset;
+  ANALYTICS_WORKER_SECRET: string;
+  CF_ACCOUNT_ID: string;
+  CF_ANALYTICS_TOKEN: string;
+}
+
+type EventKind = "mcp" | "api" | "page";
+type Window = "7d" | "30d" | "90d";
+
+interface TrackPayload {
+  kind: EventKind;
+  name: string;
+  sessionHash: string;
+  latencyMs?: number;
+}
+
+interface QueryPayload {
+  window: Window;
+}
+
+interface KindStats {
+  total: number;
+  uv: number;
+  byName: Array<{ name: string; hits: number }>;
+}
+
+interface QueryResult {
+  window: Window;
+  generatedAt: string;
+  mcp: KindStats;
+  api: KindStats;
+  page: KindStats;
+}
+
+const REPLAY_WINDOW_MS = 5 * 60 * 1000;
+const WINDOW_DAYS: Record<Window, number> = { "7d": 7, "30d": 30, "90d": 90 };
+const DATASET = "dify_watchdog_events";
+
+const encoder = new TextEncoder();
+
+const toHex = (buf: ArrayBuffer): string =>
+  [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+const constantTimeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+};
+
+const verifyHmac = async (
+  secret: string,
+  timestamp: string,
+  body: string,
+  signature: string,
+): Promise<boolean> => {
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(Date.now() - ts) > REPLAY_WINDOW_MS) return false;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sigBytes = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${timestamp}.${body}`),
+  );
+  return constantTimeEqual(toHex(sigBytes), signature.toLowerCase());
+};
+
+const authenticate = async (
+  req: Request,
+  env: Env,
+): Promise<{ body: string; payload: unknown } | Response> => {
+  const ts = req.headers.get("X-Timestamp");
+  const sig = req.headers.get("X-Signature");
+  if (!ts || !sig) {
+    return new Response("missing signature headers", { status: 401 });
+  }
+  const body = await req.text();
+  const ok = await verifyHmac(env.ANALYTICS_WORKER_SECRET, ts, body, sig);
+  if (!ok) {
+    return new Response("bad signature", { status: 401 });
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return new Response("invalid json", { status: 400 });
+  }
+  return { body, payload };
+};
+
+const isTrackPayload = (x: unknown): x is TrackPayload => {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return (
+    (o.kind === "mcp" || o.kind === "api" || o.kind === "page") &&
+    typeof o.name === "string" &&
+    o.name.length > 0 &&
+    o.name.length <= 256 &&
+    typeof o.sessionHash === "string" &&
+    o.sessionHash.length > 0 &&
+    o.sessionHash.length <= 128 &&
+    (o.latencyMs === undefined || typeof o.latencyMs === "number")
+  );
+};
+
+const isQueryPayload = (x: unknown): x is QueryPayload => {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return o.window === "7d" || o.window === "30d" || o.window === "90d";
+};
+
+const handleTrack = async (
+  payload: unknown,
+  env: Env,
+): Promise<Response> => {
+  if (!isTrackPayload(payload)) {
+    return new Response("invalid track payload", { status: 400 });
+  }
+
+  env.EVENTS.writeDataPoint({
+    blobs: [payload.kind, payload.name],
+    indexes: [payload.sessionHash],
+    doubles: [payload.latencyMs ?? 0],
+  });
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 202,
+    headers: { "content-type": "application/json" },
+  });
+};
+
+interface AnalyticsRow {
+  name?: string;
+  hits?: number;
+  uv?: number;
+}
+
+interface AnalyticsResponse {
+  data?: AnalyticsRow[];
+}
+
+const runSql = async (
+  env: Env,
+  sql: string,
+): Promise<AnalyticsRow[]> => {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/analytics_engine/sql`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.CF_ANALYTICS_TOKEN}`,
+      "Content-Type": "text/plain",
+    },
+    body: sql,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`analytics_engine sql ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as AnalyticsResponse;
+  return json.data ?? [];
+};
+
+const escapeKind = (kind: EventKind): string => {
+  // kind comes from a closed enum so it's safe; defensive sanitize anyway.
+  return kind.replace(/[^a-z]/g, "");
+};
+
+const queryKind = async (
+  env: Env,
+  kind: EventKind,
+  days: number,
+): Promise<KindStats> => {
+  const safeKind = escapeKind(kind);
+  const breakdownSql = `
+    SELECT
+      blob2 AS name,
+      sum(_sample_interval) AS hits
+    FROM ${DATASET}
+    WHERE blob1 = '${safeKind}'
+      AND timestamp > NOW() - INTERVAL '${days}' DAY
+    GROUP BY name
+    ORDER BY hits DESC
+    LIMIT 20
+    FORMAT JSON
+  `;
+  const totalSql = `
+    SELECT
+      sum(_sample_interval) AS hits,
+      uniq(index1) AS uv
+    FROM ${DATASET}
+    WHERE blob1 = '${safeKind}'
+      AND timestamp > NOW() - INTERVAL '${days}' DAY
+    FORMAT JSON
+  `;
+
+  const [breakdown, totals] = await Promise.all([
+    runSql(env, breakdownSql),
+    runSql(env, totalSql),
+  ]);
+
+  const totalRow = totals[0] ?? {};
+  return {
+    total: Number(totalRow.hits ?? 0),
+    uv: Number(totalRow.uv ?? 0),
+    byName: breakdown.map((row) => ({
+      name: String(row.name ?? ""),
+      hits: Number(row.hits ?? 0),
+    })),
+  };
+};
+
+const handleQuery = async (
+  payload: unknown,
+  env: Env,
+): Promise<Response> => {
+  if (!isQueryPayload(payload)) {
+    return new Response("invalid query payload", { status: 400 });
+  }
+  const days = WINDOW_DAYS[payload.window];
+
+  try {
+    const [mcp, api, page] = await Promise.all([
+      queryKind(env, "mcp", days),
+      queryKind(env, "api", days),
+      queryKind(env, "page", days),
+    ]);
+    const result: QueryResult = {
+      window: payload.window,
+      generatedAt: new Date().toISOString(),
+      mcp,
+      api,
+      page,
+    };
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "query failed";
+    return new Response(
+      JSON.stringify({ error: "query_failed", message }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+};
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    if (req.method !== "POST") {
+      return new Response("method not allowed", { status: 405 });
+    }
+    const url = new URL(req.url);
+    const auth = await authenticate(req, env);
+    if (auth instanceof Response) return auth;
+
+    if (url.pathname === "/track") {
+      return handleTrack(auth.payload, env);
+    }
+    if (url.pathname === "/query") {
+      return handleQuery(auth.payload, env);
+    }
+    return new Response("not found", { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;

--- a/cloudflare/analytics-worker/tsconfig.json
+++ b/cloudflare/analytics-worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cloudflare/analytics-worker/wrangler.toml
+++ b/cloudflare/analytics-worker/wrangler.toml
@@ -1,0 +1,28 @@
+# Cloudflare Worker that ingests analytics events for dify-helm-watchdog
+# and exposes a query endpoint for the public /dashboard page.
+#
+# Setup checklist (one-time):
+#   1. wrangler login
+#   2. Replace YOUR-DOMAIN.com below with your real apex domain
+#   3. wrangler secret put ANALYTICS_WORKER_SECRET   # shared with Vercel for HMAC
+#   4. wrangler secret put CF_ACCOUNT_ID             # for Analytics Engine SQL API
+#   5. wrangler secret put CF_ANALYTICS_TOKEN        # API token, scope: Account Analytics:Read
+#   6. wrangler deploy
+
+name = "dify-watchdog-analytics"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+
+# Analytics Engine binding for writes. Reads go through the SQL API (see secrets above).
+[[analytics_engine_datasets]]
+binding = "EVENTS"
+dataset = "dify_watchdog_events"
+
+# Custom domain. Replace YOUR-DOMAIN.com with the apex zone you own in Cloudflare.
+# Workers will create the DNS record automatically once the zone is in your account.
+[[routes]]
+pattern = "analytics.YOUR-DOMAIN.com"
+custom_domain = true
+
+[observability]
+enabled = true

--- a/cloudflare/analytics-worker/wrangler.toml
+++ b/cloudflare/analytics-worker/wrangler.toml
@@ -21,7 +21,7 @@ dataset = "dify_watchdog_events"
 # Custom domain. Replace YOUR-DOMAIN.com with the apex zone you own in Cloudflare.
 # Workers will create the DNS record automatically once the zone is in your account.
 [[routes]]
-pattern = "analytics.YOUR-DOMAIN.com"
+pattern = "dify-watchdog-analytics.langgenius.app"
 custom_domain = true
 
 [observability]

--- a/dify-helm-watchdog/.env.example
+++ b/dify-helm-watchdog/.env.example
@@ -1,2 +1,9 @@
 BLOB_READ_WRITE_TOKEN="vercel_blob_rw_vExxxxxxxxxxxxZ"
 CRON_API_KEY=xxxxxx
+
+# Cloudflare-backed analytics (see /dashboard).
+# Worker code lives in cloudflare/analytics-worker. Leave blank to disable
+# tracking entirely; the dashboard will render with empty stats.
+ANALYTICS_WORKER_URL="https://analytics.helm-watchdog.dify.ai"
+ANALYTICS_WORKER_SECRET="hex32 from openssl rand -hex 32"
+ANALYTICS_SESSION_SALT="hex32 from openssl rand -hex 32"

--- a/dify-helm-watchdog/docs/architecture_overview.html
+++ b/dify-helm-watchdog/docs/architecture_overview.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<title>dify-helm-watchdog · 架构总览</title>
+<style>
+  :root {
+    --bg: #fafaf9;
+    --ink: #0f172a;
+    --muted: #475569;
+    --subtle: #94a3b8;
+    --line: #cbd5e1;
+
+    --done-fill: #e7f8ef; --done-border: #10b981; --done-dot: #10b981;
+    --wip-fill:  #d3f5ea; --wip-border:  #14b8a6; --wip-dot:  #0d9488;
+    --plan-fill: #efe9fe; --plan-border: #8b5cf6; --plan-dot: #7c3aed;
+
+    --store-fill: #f3f4f6; --store-border: #9ca3af;
+    --core-fill:  #ccfbf1; --core-border:  #0d9488;
+    --rrf-fill:   #ffedd5; --rrf-border:   #ea580c;
+    --orch-fill:  #ecfeff; --orch-border:  #0891b2;
+  }
+
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue",
+                 "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+    font-size: 13px; line-height: 1.45;
+  }
+
+  .board {
+    max-width: 1760px; margin: 24px auto; padding: 24px 28px 36px;
+    background: #fff; border-radius: 16px;
+    box-shadow: 0 1px 2px rgba(15,23,42,.04), 0 8px 30px rgba(15,23,42,.05);
+    position: relative;
+  }
+
+  .connections {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    pointer-events: none; z-index: 1; overflow: visible;
+  }
+  .connections path {
+    fill: none; stroke: #94a3b8; stroke-width: 1.4;
+    stroke-dasharray: 5 4; opacity: .75;
+  }
+  .connections path.strong { stroke: #475569; opacity: .85; stroke-width: 1.7; }
+  .connections .arrowhead { fill: #94a3b8; }
+  .row, header.top, .footer-note { position: relative; z-index: 2; }
+
+  header.top {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    margin-bottom: 18px;
+  }
+  header.top h1 { font-size: 18px; margin: 0; letter-spacing: .5px; }
+  header.top .sub { color: var(--muted); margin-left: 10px; font-size: 12px; }
+
+  .legend {
+    display: flex; flex-direction: column; gap: 6px;
+    font-size: 12px; color: var(--muted); align-items: flex-end;
+  }
+  .legend-group {
+    display: flex; gap: 14px; align-items: center;
+    flex-wrap: wrap; justify-content: flex-end;
+  }
+  .legend-title {
+    color: var(--ink); font-weight: 600; font-size: 11px;
+    letter-spacing: .5px; min-width: 40px;
+  }
+  .legend .item { display: flex; align-items: center; gap: 6px; white-space: nowrap; }
+  .dot {
+    width: 10px; height: 10px; border-radius: 50%; display: inline-block;
+    box-shadow: 0 0 0 2px #fff, 0 0 0 3px rgba(0,0,0,.06);
+  }
+  .dot.done { background: var(--done-dot); }
+  .dot.wip  { background: var(--wip-dot); }
+  .dot.plan {
+    background: var(--plan-fill);
+    border: 1.5px dashed var(--plan-border);
+    box-shadow: none; width: 12px; height: 12px;
+  }
+  .swatch {
+    display: inline-block; width: 14px; height: 10px;
+    border-radius: 3px; border: 1.5px solid transparent;
+  }
+  .swatch.store { background: var(--store-fill); border-color: var(--store-border); }
+  .swatch.core  { background: var(--core-fill);  border-color: var(--core-border); }
+  .swatch.orch  { background: var(--orch-fill);  border-color: var(--orch-border); }
+  .swatch.rrf   { background: var(--rrf-fill);   border-color: var(--rrf-border); }
+
+  .row {
+    display: grid; grid-template-columns: 130px 1fr;
+    gap: 16px; margin-bottom: 56px; align-items: stretch;
+  }
+  .row:last-of-type { margin-bottom: 14px; }
+  .row-label {
+    color: var(--muted); font-size: 13px; padding-top: 10px;
+    white-space: nowrap; letter-spacing: .3px;
+  }
+  .row-label .num { color: var(--ink); font-weight: 600; margin-right: 4px; }
+
+  .cards { display: flex; flex-wrap: wrap; gap: 14px; align-items: stretch; }
+
+  .card {
+    position: relative; min-width: 180px; max-width: 240px; flex: 1 1 190px;
+    padding: 12px 14px; border: 1.5px solid var(--done-border);
+    background: var(--done-fill); border-radius: 14px;
+    box-shadow: 0 1px 0 rgba(15,23,42,.03);
+  }
+  .card .title { font-weight: 600; font-size: 14px; margin-bottom: 4px; letter-spacing: .2px; }
+  .card .desc  { color: var(--muted); font-size: 12px; line-height: 1.55; }
+  .card code {
+    font-family: "SF Mono", Menlo, Consolas, monospace; font-size: 11px;
+    color: #334155; background: rgba(15,23,42,.04);
+    padding: 1px 4px; border-radius: 4px;
+  }
+  .card .status {
+    position: absolute; top: 10px; right: 10px;
+    width: 10px; height: 10px; border-radius: 50%;
+  }
+
+  .card.done { background: var(--done-fill); border-color: var(--done-border); }
+  .card.done .status { background: var(--done-dot); }
+  .card.wip  { background: var(--wip-fill);  border-color: var(--wip-border); }
+  .card.wip  .status { background: var(--wip-dot); }
+  .card.plan { background: var(--plan-fill); border: 1.5px dashed var(--plan-border); }
+  .card.plan .status { background: var(--plan-dot); }
+
+  .card.store { background: var(--store-fill); border-color: var(--store-border); }
+  .card.store .status { background: #9ca3af; }
+  .card.core  {
+    background: var(--core-fill); border-color: var(--core-border);
+    min-width: 260px; max-width: 300px;
+  }
+  .card.core .status { background: var(--wip-dot); }
+  .card.orch  {
+    background: var(--orch-fill); border-color: var(--orch-border);
+    min-width: 240px; max-width: 280px;
+  }
+  .card.orch .status { background: var(--orch-border); }
+  .card.rrf   { background: var(--rrf-fill); border-color: var(--rrf-border); }
+  .card.rrf .status { background: var(--rrf-border); }
+
+  .card .tag {
+    display: inline-block; margin-top: 6px;
+    font-size: 11px; color: #0369a1;
+    background: rgba(14,165,233,.1);
+    padding: 1px 6px; border-radius: 4px;
+  }
+
+  .arrow {
+    display: flex; align-items: center; justify-content: center;
+    color: var(--subtle); font-size: 22px; font-weight: 300;
+    padding: 0 2px; user-select: none; min-width: 14px;
+  }
+  .arrow.fan   { color: var(--orch-border); font-size: 20px; }
+  .arrow.merge { color: var(--rrf-border);  font-size: 20px; }
+  .arrow.soft  { color: var(--subtle); font-size: 14px; }
+
+  .divider {
+    width: 1px; background: var(--line); margin: 4px 6px; align-self: stretch;
+  }
+  .divider-label {
+    display: flex; align-items: center; color: var(--subtle);
+    font-size: 11px; letter-spacing: 1px; padding: 0 2px;
+  }
+
+  .footer-note {
+    margin-top: 14px; color: var(--muted); font-size: 11.5px;
+    border-top: 1px dashed var(--line); padding-top: 10px;
+    display: flex; flex-wrap: wrap; gap: 18px;
+  }
+  .footer-note b { color: var(--ink); }
+</style>
+</head>
+<body>
+<div class="board">
+  <svg class="connections" aria-hidden="true">
+    <defs>
+      <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+        <path d="M0,0 L10,5 L0,10 Z" class="arrowhead" />
+      </marker>
+      <marker id="arr-strong" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+        <path d="M0,0 L10,5 L0,10 Z" fill="#475569" />
+      </marker>
+    </defs>
+  </svg>
+
+  <header class="top">
+    <div>
+      <h1>dify-helm-watchdog · 系统架构总览<span class="sub">Next.js 15 · React 19 · Vercel Blob · MCP · Cloudflare Analytics Engine · 每日快照 Dify Helm Chart</span></h1>
+    </div>
+    <div class="legend">
+      <div class="legend-group">
+        <span class="legend-title">状态</span>
+        <div class="item"><span class="dot done"></span>已实现</div>
+        <div class="item"><span class="dot wip"></span>进行中</div>
+        <div class="item"><span class="dot plan"></span>规划中（虚线边框）</div>
+      </div>
+      <div class="legend-group">
+        <span class="legend-title">角色</span>
+        <div class="item"><span class="swatch store"></span>存储 / 外部数据源</div>
+        <div class="item"><span class="swatch core"></span>核心存储</div>
+        <div class="item"><span class="swatch orch"></span>调度器 / 分发器</div>
+        <div class="item"><span class="swatch rrf"></span>融合 / 聚合</div>
+      </div>
+    </div>
+  </header>
+
+  <!-- ① 上游数据源 — parallel external systems (· soft) -->
+  <div class="row">
+    <div class="row-label"><span class="num">①</span>上游</div>
+    <div class="cards">
+      <div class="card store" id="card-helm-index">
+        <div class="status"></div>
+        <div class="title">Helm Index</div>
+        <div class="desc"><code>langgenius.github.io/dify-helm/index.yaml</code> · 版本清单</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card store" id="card-helm-chart">
+        <div class="status"></div>
+        <div class="title">Chart Tarball</div>
+        <div class="desc">每版本 <code>.tgz</code>，通过 <code>tar-stream + gunzip</code> 提取 <code>values.yaml</code></div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card store" id="card-coding-reg">
+        <div class="status"></div>
+        <div class="title">Coding 镜像仓库</div>
+        <div class="desc"><code>g-hsod9681-docker.pkg.coding.net/dify-artifact/dify</code> · 对 3 种变体查询 manifest：<code>ORIGINAL / AMD64 / ARM64</code></div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card store" id="card-ee-release">
+        <div class="status"></div>
+        <div class="title">ee.dify.ai</div>
+        <div class="desc">v ≥ 3.9.0 的 Release 页 HTML，经裁剪后由 <code>turndown</code> 转 Markdown</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card store" id="card-docs-site">
+        <div class="status"></div>
+        <div class="title">Helm Docs</div>
+        <div class="desc"><code>dify-helm/pages/{x_y_z}.md</code> · v &lt; 3.9.0 的原生 Markdown</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card store" id="card-dify-api">
+        <div class="status"></div>
+        <div class="title">Dify API</div>
+        <div class="desc"><code>api.dify.ai/v1/workflows/logs</code> · 需 <code>DIFY_API_KEY</code>，超时 30s</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ② 调度流水线 — sequential pipeline (→) -->
+  <div class="row">
+    <div class="row-label"><span class="num">②</span>调度</div>
+    <div class="cards">
+      <div class="card done" id="card-vercel-cron">
+        <div class="status"></div>
+        <div class="title">Vercel Cron</div>
+        <div class="desc">每日 UTC 02:00 触发 <code>"0 2 * * *"</code>（<code>vercel.json</code>），通过 <code>x-vercel-cron</code> 头免鉴权</div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="card done" id="card-cron-route">
+        <div class="status"></div>
+        <div class="title">POST /api/v1/cron</div>
+        <div class="desc">流式 <code>text/plain</code> 输出 <code>[sync]/[result]/[status]</code>；支持 <code>?version=</code> 强制刷新与 <code>?pause=</code>（≤300s，10s 心跳）；外部调用需 <code>Bearer CRON_API_KEY</code></div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="card orch" id="card-sync">
+        <div class="status"></div>
+        <div class="title">syncHelmData()</div>
+        <div class="desc"><code>lib/helm.ts</code> · fetch index → 下载 tgz → 提取 values → 收集 <code>image</code> 条目 → registry 验证 3 变体 → 写 Blob / 本地；完成后 <code>revalidatePath("/")</code> + 可选 homepage warmup</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ③ 存储层 — storage factory fans out to blob + local -->
+  <div class="row">
+    <div class="row-label"><span class="num">③</span>存储</div>
+    <div class="cards">
+      <div class="card orch" id="card-storage-factory">
+        <div class="status"></div>
+        <div class="title">Storage Factory</div>
+        <div class="desc"><code>services/storage.ts</code> · 根据 <code>ENABLE_LOCAL_MODE</code> 选择 Blob 或 Local 实现（<code>read/readContent/write/ensureAccess</code>）</div>
+      </div>
+      <div class="arrow fan">⇉</div>
+      <div class="card core" id="card-blob">
+        <div class="status"></div>
+        <div class="title">Vercel Blob</div>
+        <div class="desc">前缀 <code>helm-watchdog/</code> ·
+          <code>cache.json</code> ·
+          <code>values/{v}.yaml</code> ·
+          <code>images/{v}.yaml</code> ·
+          <code>image-validation/{v}.json</code> ·
+          <code>workflow-logs.json</code>
+        </div>
+      </div>
+      <div class="divider"></div>
+      <div class="divider-label">旁路 · 开发模式</div>
+      <div class="card store" id="card-local">
+        <div class="status"></div>
+        <div class="title">本地缓存</div>
+        <div class="desc"><code>.cache/helm/</code> · 本地模式下最多处理 5 个最新版本加速开发</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ④ 域逻辑库 — parallel independent libs (· soft) -->
+  <div class="row">
+    <div class="row-label"><span class="num">④</span>域逻辑</div>
+    <div class="cards">
+      <div class="card done" id="card-loadcache">
+        <div class="status"></div>
+        <div class="title">loadCache()</div>
+        <div class="desc"><code>lib/helm.ts</code> · 读 <code>cache.json</code> → 规范化时间戳 → 为每个版本并行拉取 inline 内容（values / images / validation）供 ISR 渲染</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-validation">
+        <div class="status"></div>
+        <div class="title">validation.ts</div>
+        <div class="desc">规范化 <code>ImageValidationPayload</code>，聚合 <code>ALL_FOUND / PARTIAL / MISSING / ERROR</code>；若 ORIGINAL 存在即视为可用</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-release-notes">
+        <div class="status"></div>
+        <div class="title">release-notes.ts</div>
+        <div class="desc">v ≥ 3.9.0 抓 <code>ee.dify.ai</code> HTML → 定位主容器 div → 重写相对链接 → <code>turndown</code> 转 MD；更老版本直接读 docs MD 并规范化链接</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-wizard">
+        <div class="status"></div>
+        <div class="title">values-wizard.ts</div>
+        <div class="desc">将旧版 overrides 合并进新版模板：保留用户 <code>repository</code>，强制使用新版 <code>tag</code>；输出变更报告（added/updated/unchanged/removed）</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-workflow-log-lib">
+        <div class="status"></div>
+        <div class="title">workflow-logs.ts</div>
+        <div class="desc">拉 Dify 运行日志；脱敏邮箱字段；刷新有 <code>RATE_LIMIT_MS = 5 min</code> 限流</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ⑤ API 暴露面 — parallel endpoints (· soft) -->
+  <div class="row">
+    <div class="row-label"><span class="num">⑤</span>API</div>
+    <div class="cards">
+      <div class="card done" id="card-rest-v1">
+        <div class="status"></div>
+        <div class="title">REST v1</div>
+        <div class="desc"><code>/versions</code>（可 <code>?includeValidation</code>）·
+          <code>/versions/latest</code> ·
+          <code>/versions/{v}</code> /<code>/images</code> /<code>/values</code> /<code>/validation</code> ·
+          <code>/cache</code> · 带 <code>s-maxage</code> 缓存头
+        </div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-releases-api">
+        <div class="status"></div>
+        <div class="title">/api/v1/releases/{v}</div>
+        <div class="desc">代理 ee.dify.ai 发布页并裁剪为纯净 HTML，<code>revalidate: 3600</code></div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-workflow-api">
+        <div class="status"></div>
+        <div class="title">/api/v1/workflow-logs</div>
+        <div class="desc">GET 读缓存 · POST 刷新（5 分钟限流，先记 <code>lastAttemptTime</code> 再请求上游）</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card orch" id="card-mcp">
+        <div class="status"></div>
+        <div class="title">MCP · /api/v1/mcp</div>
+        <div class="desc">JSON-RPC 2.0 分发器 · 6 tools：<code>list_versions / get_latest_version / get_version_details / list_images / validate_images / get_version_release_notes</code> · 2 prompts</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-sse">
+        <div class="status"></div>
+        <div class="title">/api/v1/sse</div>
+        <div class="desc">MCP 的 Server-Sent Events 传输；按 <code>sessionId</code> 路由消息</div>
+      </div>
+      <div class="divider"></div>
+      <div class="divider-label">文档</div>
+      <div class="card done" id="card-openapi">
+        <div class="status"></div>
+        <div class="title">OpenAPI</div>
+        <div class="desc"><code>next-swagger-doc</code> 从路由 JSDoc 生成 <code>/openapi.json</code></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ⑥ 观测链路 — write path followed by aggregate query surfaces -->
+  <div class="row">
+    <div class="row-label"><span class="num">⑥</span>观测</div>
+    <div class="cards">
+      <div class="card orch" id="card-analytics-instrumentation">
+        <div class="status"></div>
+        <div class="title">Request Instrumentation</div>
+        <div class="desc"><code>middleware.ts</code> 记录首页与非排除的 <code>/api/v1/*</code> 调用；<code>mcp/handler.ts</code> 在 <code>tools/call</code> 成功或失败后记录工具名与耗时</div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="card done" id="card-analytics-client">
+        <div class="status"></div>
+        <div class="title">analytics/session + track</div>
+        <div class="desc"><code>SHA-256(IP+UA+salt)</code> 生成 session hash；<code>track.ts</code> 用 <code>ANALYTICS_WORKER_SECRET</code> 做 HMAC，写入超时 2s 且吞掉错误</div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="card orch" id="card-analytics-worker">
+        <div class="status"></div>
+        <div class="title">Cloudflare Worker</div>
+        <div class="desc"><code>/track</code> 写入事件，<code>/query</code> 查询聚合；校验 <code>X-Timestamp</code> + <code>X-Signature</code>，重放窗口 5 分钟</div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="card core" id="card-analytics-engine">
+        <div class="status"></div>
+        <div class="title">Analytics Engine</div>
+        <div class="desc">数据集 <code>dify_watchdog_events</code>；<code>blob1/blob2</code> 存 kind/name，<code>index1</code> 存 session hash，<code>double1</code> 存 latency</div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="card done" id="card-analytics-api">
+        <div class="status"></div>
+        <div class="title">GET /api/v1/analytics</div>
+        <div class="desc">窗口 <code>7d / 30d / 90d</code>；返回 MCP / REST / page 的 total、UV 与 Top 20 名称分布；CDN 缓存 <code>s-maxage=300</code> / <code>stale=900</code></div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-dashboard">
+        <div class="status"></div>
+        <div class="title">/dashboard</div>
+        <div class="desc"><code>force-dynamic</code> 服务端页面；<code>WindowToggle</code> 切换 <code>7d/30d/90d</code>，三栏展示 MCP tool calls、REST API requests、Page views</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ⑦ 消费端 — parallel consumers (· soft) -->
+  <div class="row">
+    <div class="row-label"><span class="num">⑦</span>消费</div>
+    <div class="cards">
+      <div class="card done" id="card-ui">
+        <div class="status"></div>
+        <div class="title">VersionExplorer</div>
+        <div class="desc"><code>app/page.tsx</code> 服务端调 <code>loadCache</code>，ISR <code>revalidate = 86400</code>；含 values diff、values-wizard、workflow-logs、MCP 配置等弹窗</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-swagger">
+        <div class="status"></div>
+        <div class="title">Swagger UI</div>
+        <div class="desc"><code>/swagger</code> · 渲染 <code>/openapi.json</code></div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-mcp-clients">
+        <div class="status"></div>
+        <div class="title">MCP AI Clients</div>
+        <div class="desc">Claude Code / IDE 代理通过 Streamable HTTP 或 SSE 调用 6 个工具</div>
+      </div>
+      <div class="arrow soft">·</div>
+      <div class="card done" id="card-api-consumers">
+        <div class="status"></div>
+        <div class="title">REST 调用方</div>
+        <div class="desc">脚本 / 仪表盘 / CI · 直接消费 v1 REST JSON/YAML</div>
+      </div>
+      <div class="divider"></div>
+      <div class="divider-label">旁路 · 独立 shell 脚本（不走 Next.js）</div>
+      <div class="card store" id="card-shell">
+        <div class="status"></div>
+        <div class="title">shell 工具</div>
+        <div class="desc"><code>list-dify-versions.sh</code> · <code>get-dify-helm-images.sh</code> · <code>get-dify-values.sh</code> · 仅用于手动检查</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer-note">
+    <div><b>部署：</b> Vercel · Node.js runtime · Next.js 15.5.7 (Turbopack) · React 19.1.0 · Cloudflare Worker / Analytics Engine</div>
+    <div><b>CI/CD：</b> Vercel auto deploy · daily cron <code>0 2 * * *</code> · Cloudflare Worker 通过 <code>wrangler deploy</code> 单独发布</div>
+    <div><b>环境变量：</b> <code>BLOB_READ_WRITE_TOKEN</code> + 可选 <code>CRON_API_KEY</code> / <code>DIFY_API_KEY</code> / <code>ANALYTICS_WORKER_URL</code> / <code>ANALYTICS_WORKER_SECRET</code> / <code>ANALYTICS_SESSION_SALT</code></div>
+    <div><b>测试：</b> Jest · API route、MCP、analytics、middleware、values wizard 等测试位于 <code>src/test/</code></div>
+    <div><b>术语：</b> <code>chart</code>（Helm 包）· <code>values.yaml</code>（部署配置）· <code>image variant</code>（ORIGINAL/AMD64/ARM64）· <code>Analytics Engine</code>（Cloudflare 事件聚合）· <code>EE</code>（Enterprise）</div>
+  </div>
+</div>
+
+<script>
+(function () {
+  // Cross-layer semantic connections. Format: [fromId, toId, strong?]
+  // Only edges that represent a real data/control flow. Do NOT connect row-to-row.
+  const CONNECTIONS = [
+    // ① upstream → ② sync pipeline
+    ['card-helm-index', 'card-sync'],
+    ['card-helm-chart', 'card-sync'],
+    ['card-coding-reg', 'card-sync'],
+
+    // ① upstream → ④ domain libs (libs hit upstream directly, bypassing cron)
+    ['card-ee-release',      'card-release-notes'],
+    ['card-docs-site',       'card-release-notes'],
+    ['card-dify-api',        'card-workflow-log-lib'],
+
+    // ② sync → ③ storage (write path)
+    ['card-sync', 'card-storage-factory', true],
+
+    // ③ → ④ read path (loadCache reads from blob; local fallback)
+    ['card-blob',  'card-loadcache', true],
+    ['card-local', 'card-loadcache'],
+
+    // ④ → ⑤ domain libs feed API routes
+    ['card-loadcache',         'card-rest-v1'],
+    ['card-loadcache',         'card-mcp'],
+    ['card-validation',        'card-rest-v1'],
+    ['card-release-notes',     'card-releases-api'],
+    ['card-release-notes',     'card-mcp'],
+    ['card-workflow-log-lib',  'card-workflow-api'],
+
+    // ④ → ⑦ skip: SSR renders UI directly from loadCache; wizard runs client-side
+    ['card-loadcache', 'card-ui', true],
+    ['card-wizard',    'card-ui'],
+
+    // ⑤ → ⑥ observability
+    ['card-rest-v1', 'card-analytics-instrumentation'],
+    ['card-mcp',     'card-analytics-instrumentation'],
+    ['card-sse',     'card-analytics-instrumentation'],
+
+    // ⑤/⑥ → ⑦ consumers
+    ['card-rest-v1',      'card-api-consumers'],
+    ['card-rest-v1',      'card-ui'],
+    ['card-releases-api', 'card-ui'],
+    ['card-workflow-api', 'card-ui'],
+    ['card-mcp',          'card-mcp-clients'],
+    ['card-sse',          'card-mcp-clients'],
+    ['card-openapi',      'card-swagger'],
+    ['card-analytics-api', 'card-api-consumers'],
+  ];
+
+  function draw() {
+    const svg = document.querySelector('.connections');
+    const board = document.querySelector('.board');
+    if (!svg || !board) return;
+
+    [...svg.querySelectorAll('path.conn')].forEach(p => p.remove());
+
+    const bRect = board.getBoundingClientRect();
+    const width  = board.scrollWidth  || bRect.width;
+    const height = board.scrollHeight || bRect.height;
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('width', width);
+    svg.setAttribute('height', height);
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+
+    for (const [fromId, toId, strong] of CONNECTIONS) {
+      const a = document.getElementById(fromId);
+      const b = document.getElementById(toId);
+      if (!a || !b) continue;
+
+      const ar = a.getBoundingClientRect();
+      const br = b.getBoundingClientRect();
+      const x1 = ar.left + ar.width / 2 - bRect.left;
+      const y1 = ar.bottom              - bRect.top;
+      const x2 = br.left + br.width / 2 - bRect.left;
+      const y2 = br.top                 - bRect.top - 2;
+
+      const dy = Math.max(30, (y2 - y1) * 0.55);
+      const d = `M ${x1} ${y1} C ${x1} ${y1 + dy}, ${x2} ${y2 - dy}, ${x2} ${y2}`;
+
+      const p = document.createElementNS(SVG_NS, 'path');
+      p.setAttribute('d', d);
+      p.setAttribute('class', strong ? 'conn strong' : 'conn');
+      p.setAttribute('marker-end', strong ? 'url(#arr-strong)' : 'url(#arr)');
+      svg.appendChild(p);
+    }
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    requestAnimationFrame(draw);
+  } else {
+    window.addEventListener('DOMContentLoaded', () => requestAnimationFrame(draw));
+  }
+  window.addEventListener('load',   draw);
+  window.addEventListener('resize', draw);
+
+  if (window.ResizeObserver) {
+    new ResizeObserver(() => draw()).observe(document.querySelector('.board'));
+  }
+})();
+</script>
+</body>
+</html>

--- a/dify-helm-watchdog/src/app/api/v1/analytics/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/analytics/route.ts
@@ -1,0 +1,62 @@
+import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
+import { queryAnalytics } from "@/lib/analytics/track";
+
+export const runtime = "nodejs";
+
+const ALLOWED_WINDOWS = ["7d", "30d", "90d"] as const;
+type WindowParam = (typeof ALLOWED_WINDOWS)[number];
+
+const parseWindow = (raw: string | null): WindowParam => {
+  if (raw && (ALLOWED_WINDOWS as readonly string[]).includes(raw)) {
+    return raw as WindowParam;
+  }
+  return "7d";
+};
+
+/**
+ * @swagger
+ * /api/v1/analytics:
+ *   get:
+ *     summary: Aggregate analytics for MCP / API / Web traffic
+ *     description: |
+ *       Returns aggregated counts and unique-visitor estimates for the public
+ *       dashboard. Backed by Cloudflare Analytics Engine.
+ *     tags:
+ *       - Analytics
+ *     parameters:
+ *       - name: window
+ *         in: query
+ *         schema:
+ *           type: string
+ *           enum: ["7d", "30d", "90d"]
+ *         description: Time window. Defaults to 7d.
+ *     responses:
+ *       200:
+ *         description: Aggregated analytics for the requested window.
+ *       502:
+ *         description: Upstream Cloudflare Worker query failed.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const window = parseWindow(url.searchParams.get("window"));
+
+  try {
+    const data = await queryAnalytics(window);
+    return createJsonResponse(data, {
+      request,
+      headers: {
+        "Cache-Control":
+          "public, s-maxage=300, stale-while-revalidate=900",
+      },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "analytics query failed";
+    return createErrorResponse({
+      request,
+      status: 502,
+      message,
+      statusText: "UNAVAILABLE",
+    });
+  }
+}

--- a/dify-helm-watchdog/src/app/api/v1/mcp/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/mcp/route.ts
@@ -8,6 +8,7 @@
 
 import { handleJsonMessage, handleMessage } from "@/lib/mcp/handler";
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
+import { computeSessionHashFromRequest } from "@/lib/analytics/session";
 import {
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_NAME,
@@ -221,10 +222,12 @@ export async function POST(request: Request) {
       );
     }
 
+    const sessionHash = await computeSessionHashFromRequest(request);
+
     // Handle batch requests
     if (Array.isArray(parsed)) {
       const responses = await Promise.all(
-        parsed.map((message) => handleMessage(message)),
+        parsed.map((message) => handleMessage(message, sessionHash)),
       );
 
       // Filter out null responses (notifications)
@@ -245,7 +248,7 @@ export async function POST(request: Request) {
     }
 
     // Handle single request
-    const response = await handleJsonMessage(body);
+    const response = await handleJsonMessage(body, sessionHash);
 
     if (response === null) {
       // Notification - no response needed

--- a/dify-helm-watchdog/src/app/api/v1/sse/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/sse/route.ts
@@ -9,6 +9,7 @@
 import { createSession, getSession, touchSession, deleteSession } from "@/lib/mcp/session";
 import { handleJsonMessage, formatSseEvent } from "@/lib/mcp/handler";
 import { createErrorResponse } from "@/lib/api/response";
+import { computeSessionHashFromRequest } from "@/lib/analytics/session";
 
 export const runtime = "nodejs";
 
@@ -146,7 +147,8 @@ export async function POST(request: Request) {
     }
 
     // Process the message
-    const response = await handleJsonMessage(body);
+    const sessionHash = await computeSessionHashFromRequest(request);
+    const response = await handleJsonMessage(body, sessionHash);
 
     // If sessionId is provided and we have an active SSE connection, send via SSE
     if (sessionId) {

--- a/dify-helm-watchdog/src/app/dashboard/page.tsx
+++ b/dify-helm-watchdog/src/app/dashboard/page.tsx
@@ -1,0 +1,177 @@
+import type { Metadata } from "next";
+
+import { queryAnalytics, type AnalyticsQueryResponse, type KindStats } from "@/lib/analytics/track";
+
+import { WindowToggle } from "./window-toggle";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description:
+    "Public usage stats for dify-helm-watchdog — MCP tool calls, REST API requests, and page views.",
+};
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_WINDOWS = ["7d", "30d", "90d"] as const;
+type WindowParam = (typeof ALLOWED_WINDOWS)[number];
+
+const parseWindow = (raw: string | string[] | undefined): WindowParam => {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value && (ALLOWED_WINDOWS as readonly string[]).includes(value)) {
+    return value as WindowParam;
+  }
+  return "7d";
+};
+
+interface PageProps {
+  searchParams: Promise<{ window?: string | string[] }>;
+}
+
+const formatNumber = (n: number): string => {
+  if (!Number.isFinite(n)) return "0";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString("en-US");
+};
+
+interface PanelProps {
+  title: string;
+  subtitle: string;
+  stats: KindStats;
+  showBreakdown: boolean;
+}
+
+function Panel({ title, subtitle, stats, showBreakdown }: PanelProps) {
+  const top = stats.byName.slice(0, 5);
+  const max = top.reduce((m, r) => (r.hits > m ? r.hits : m), 0) || 1;
+
+  return (
+    <section className="flex flex-col gap-4 rounded-lg border border-zinc-800/80 bg-zinc-950/50 p-5">
+      <header>
+        <p className="text-xs uppercase tracking-widest text-zinc-500">
+          {subtitle}
+        </p>
+        <h2 className="mt-1 font-mono text-sm text-zinc-200">{title}</h2>
+      </header>
+
+      <div className="font-mono text-4xl font-semibold tabular-nums text-emerald-300">
+        {formatNumber(stats.total)}
+      </div>
+
+      {showBreakdown && top.length > 0 ? (
+        <ul className="flex flex-col gap-1.5">
+          {top.map((row) => {
+            const pct = Math.round((row.hits / max) * 100);
+            return (
+              <li
+                key={row.name}
+                className="flex flex-col gap-0.5 font-mono text-xs"
+              >
+                <div className="flex items-baseline justify-between">
+                  <span className="truncate text-zinc-300" title={row.name}>
+                    {row.name}
+                  </span>
+                  <span className="tabular-nums text-zinc-500">
+                    {formatNumber(row.hits)}
+                  </span>
+                </div>
+                <div className="h-[3px] w-full overflow-hidden rounded-sm bg-zinc-800/80">
+                  <div
+                    className="h-full bg-emerald-500/60"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : showBreakdown ? (
+        <p className="font-mono text-xs text-zinc-600">no calls in this window</p>
+      ) : null}
+
+      <footer className="mt-auto border-t border-zinc-800/60 pt-3 font-mono text-xs text-zinc-500">
+        ≈ {formatNumber(stats.uv)} unique visitors
+      </footer>
+    </section>
+  );
+}
+
+const EMPTY_STATS: KindStats = { total: 0, uv: 0, byName: [] };
+
+export default async function DashboardPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const windowParam = parseWindow(params.window);
+
+  let data: AnalyticsQueryResponse | null = null;
+  let errorMessage: string | null = null;
+
+  try {
+    data = await queryAnalytics(windowParam);
+  } catch (error) {
+    errorMessage =
+      error instanceof Error ? error.message : "analytics unavailable";
+  }
+
+  const mcp = data?.mcp ?? EMPTY_STATS;
+  const api = data?.api ?? EMPTY_STATS;
+  const page = data?.page ?? EMPTY_STATS;
+  const generatedAt = data?.generatedAt
+    ? new Date(data.generatedAt).toLocaleString("en-US", {
+        timeZone: "UTC",
+      })
+    : null;
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-12">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-widest text-emerald-400/80">
+            usage
+          </p>
+          <h1 className="mt-1 font-mono text-2xl text-zinc-100">
+            dify-helm-watchdog
+          </h1>
+          <p className="mt-2 font-mono text-xs text-zinc-500">
+            {generatedAt
+              ? `last refreshed ${generatedAt} UTC`
+              : "live (cache 5 min)"}
+          </p>
+        </div>
+        <WindowToggle current={windowParam} />
+      </header>
+
+      {errorMessage ? (
+        <div className="rounded-md border border-red-900/40 bg-red-950/20 p-4 font-mono text-xs text-red-300">
+          analytics unavailable: {errorMessage}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Panel
+          title="MCP tool calls"
+          subtitle="model context protocol"
+          stats={mcp}
+          showBreakdown
+        />
+        <Panel
+          title="REST API requests"
+          subtitle="public json api"
+          stats={api}
+          showBreakdown
+        />
+        <Panel
+          title="Page views"
+          subtitle="web ui"
+          stats={page}
+          showBreakdown={false}
+        />
+      </div>
+
+      <footer className="font-mono text-[11px] text-zinc-600">
+        Aggregated counts only — no IPs, user agents, or request bodies are
+        stored. Unique visitor estimates use HyperLogLog over a hashed
+        IP+UA digest.
+      </footer>
+    </main>
+  );
+}

--- a/dify-helm-watchdog/src/app/dashboard/window-toggle.tsx
+++ b/dify-helm-watchdog/src/app/dashboard/window-toggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+
+const OPTIONS = [
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "90d", label: "90d" },
+] as const;
+
+interface WindowToggleProps {
+  current: "7d" | "30d" | "90d";
+}
+
+export function WindowToggle({ current }: WindowToggleProps) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [pending, startTransition] = useTransition();
+
+  const setWindow = (next: string) => {
+    const sp = new URLSearchParams(params?.toString() ?? "");
+    sp.set("window", next);
+    startTransition(() => {
+      router.replace(`/dashboard?${sp.toString()}`);
+    });
+  };
+
+  return (
+    <div
+      className="inline-flex items-center rounded-md border border-zinc-700/60 bg-zinc-900/40 p-0.5"
+      role="tablist"
+      aria-label="Time window"
+    >
+      {OPTIONS.map((opt) => {
+        const active = opt.value === current;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            disabled={pending}
+            onClick={() => setWindow(opt.value)}
+            className={[
+              "px-3 py-1 text-xs font-mono transition-colors",
+              active
+                ? "rounded bg-emerald-500/15 text-emerald-300"
+                : "text-zinc-400 hover:text-zinc-100",
+              pending ? "opacity-60" : "",
+            ].join(" ")}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dify-helm-watchdog/src/lib/analytics/session.ts
+++ b/dify-helm-watchdog/src/lib/analytics/session.ts
@@ -1,0 +1,45 @@
+const FALLBACK_SALT = "dify-watchdog-analytics-fallback";
+const encoder = new TextEncoder();
+
+const toHex = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+};
+
+const getSalt = (): string => {
+  return process.env.ANALYTICS_SESSION_SALT?.trim() || FALLBACK_SALT;
+};
+
+const extractIp = (headers: Headers): string => {
+  const forwarded = headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return (
+    headers.get("x-real-ip") ||
+    headers.get("cf-connecting-ip") ||
+    "0.0.0.0"
+  );
+};
+
+export const computeSessionHashFromHeaders = async (
+  headers: Headers,
+): Promise<string> => {
+  const ip = extractIp(headers);
+  const ua = headers.get("user-agent") ?? "";
+  const salt = getSalt();
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    encoder.encode(`${ip}\n${ua}\n${salt}`),
+  );
+  return toHex(digest);
+};
+
+export const computeSessionHashFromRequest = (
+  req: Request,
+): Promise<string> => computeSessionHashFromHeaders(req.headers);

--- a/dify-helm-watchdog/src/lib/analytics/track.ts
+++ b/dify-helm-watchdog/src/lib/analytics/track.ts
@@ -1,0 +1,129 @@
+export type EventKind = "mcp" | "api" | "page";
+
+export interface TrackEventInput {
+  kind: EventKind;
+  name: string;
+  sessionHash: string;
+  latencyMs?: number;
+}
+
+const TRACK_TIMEOUT_MS = 2000;
+const encoder = new TextEncoder();
+
+const toHex = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+};
+
+const isConfigured = (): { url: string; secret: string } | null => {
+  const url = process.env.ANALYTICS_WORKER_URL?.trim();
+  const secret = process.env.ANALYTICS_WORKER_SECRET?.trim();
+  if (!url || !secret) return null;
+  return { url: url.replace(/\/+$/, ""), secret };
+};
+
+const signBody = async (
+  secret: string,
+  timestamp: string,
+  body: string,
+): Promise<string> => {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${timestamp}.${body}`),
+  );
+  return toHex(sig);
+};
+
+export const trackEvent = async (input: TrackEventInput): Promise<void> => {
+  const cfg = isConfigured();
+  if (!cfg) return;
+
+  const body = JSON.stringify({
+    kind: input.kind,
+    name: input.name.slice(0, 256),
+    sessionHash: input.sessionHash,
+    ...(typeof input.latencyMs === "number"
+      ? { latencyMs: Math.max(0, Math.round(input.latencyMs)) }
+      : {}),
+  });
+  const timestamp = Date.now().toString();
+  const signature = await signBody(cfg.secret, timestamp, body);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TRACK_TIMEOUT_MS);
+
+  try {
+    await fetch(`${cfg.url}/track`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Timestamp": timestamp,
+        "X-Signature": signature,
+      },
+      body,
+      signal: controller.signal,
+    });
+  } catch {
+    // Analytics must never break a real request. Swallow.
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+export interface KindStats {
+  total: number;
+  uv: number;
+  byName: Array<{ name: string; hits: number }>;
+}
+
+export interface AnalyticsQueryResponse {
+  window: "7d" | "30d" | "90d";
+  generatedAt: string;
+  mcp: KindStats;
+  api: KindStats;
+  page: KindStats;
+}
+
+export const queryAnalytics = async (
+  window: "7d" | "30d" | "90d",
+): Promise<AnalyticsQueryResponse> => {
+  const cfg = isConfigured();
+  if (!cfg) {
+    throw new Error("analytics worker not configured");
+  }
+
+  const body = JSON.stringify({ window });
+  const timestamp = Date.now().toString();
+  const signature = await signBody(cfg.secret, timestamp, body);
+
+  const res = await fetch(`${cfg.url}/query`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Timestamp": timestamp,
+      "X-Signature": signature,
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `analytics query failed: ${res.status} ${text.slice(0, 200)}`,
+    );
+  }
+
+  return (await res.json()) as AnalyticsQueryResponse;
+};

--- a/dify-helm-watchdog/src/lib/mcp/handler.ts
+++ b/dify-helm-watchdog/src/lib/mcp/handler.ts
@@ -5,6 +5,7 @@
 
 import { TOOLS, executeTool } from "./tools";
 import { listPrompts, getPrompt } from "./prompts";
+import { trackEvent } from "@/lib/analytics/track";
 import {
   JSON_RPC_ERRORS,
   MCP_PROTOCOL_VERSION,
@@ -99,6 +100,7 @@ const handleToolsList = (id: string | number | undefined): JsonRpcResponse => {
 const handleToolsCall = async (
   id: string | number | undefined,
   params: McpToolCallParams,
+  sessionHash?: string,
 ): Promise<JsonRpcResponse> => {
   if (!params?.name) {
     return createErrorResponse(
@@ -117,10 +119,27 @@ const handleToolsCall = async (
     );
   }
 
+  const start = Date.now();
   try {
     const result = await executeTool(params.name, params.arguments ?? {});
+    if (sessionHash) {
+      void trackEvent({
+        kind: "mcp",
+        name: params.name,
+        sessionHash,
+        latencyMs: Date.now() - start,
+      });
+    }
     return createResponse(id, result);
   } catch (error) {
+    if (sessionHash) {
+      void trackEvent({
+        kind: "mcp",
+        name: params.name,
+        sessionHash,
+        latencyMs: Date.now() - start,
+      });
+    }
     return createErrorResponse(
       id,
       JSON_RPC_ERRORS.INTERNAL_ERROR,
@@ -163,6 +182,7 @@ const handlePromptsGet = (
 // Main message handler
 export const handleMessage = async (
   message: unknown,
+  sessionHash?: string,
 ): Promise<JsonRpcResponse | null> => {
   // Validate request format
   if (!isValidRequest(message)) {
@@ -203,7 +223,11 @@ export const handleMessage = async (
       return handleToolsList(id);
 
     case "tools/call":
-      return handleToolsCall(id, (params ?? {}) as unknown as McpToolCallParams);
+      return handleToolsCall(
+        id,
+        (params ?? {}) as unknown as McpToolCallParams,
+        sessionHash,
+      );
 
     case "prompts/list":
       return handlePromptsList(id);
@@ -223,10 +247,11 @@ export const handleMessage = async (
 // Parse and handle a JSON message string
 export const handleJsonMessage = async (
   jsonString: string,
+  sessionHash?: string,
 ): Promise<JsonRpcResponse | null> => {
   try {
     const message = JSON.parse(jsonString) as unknown;
-    return handleMessage(message);
+    return handleMessage(message, sessionHash);
   } catch {
     return createErrorResponse(
       undefined,

--- a/dify-helm-watchdog/src/middleware.ts
+++ b/dify-helm-watchdog/src/middleware.ts
@@ -1,0 +1,48 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { computeSessionHashFromHeaders } from "@/lib/analytics/session";
+import { trackEvent, type TrackEventInput } from "@/lib/analytics/track";
+
+const EXCLUDED_API_PREFIXES = ["cron", "mcp", "sse", "analytics"];
+
+const buildEvent = async (
+  req: NextRequest,
+): Promise<TrackEventInput | null> => {
+  const path = req.nextUrl.pathname;
+
+  if (path === "/") {
+    const sessionHash = await computeSessionHashFromHeaders(req.headers);
+    return { kind: "page", name: "home", sessionHash };
+  }
+
+  if (path.startsWith("/api/v1/")) {
+    const sub = path.slice("/api/v1/".length).replace(/^\/+|\/+$/g, "");
+    if (!sub) return null;
+    const head = sub.split("/")[0];
+    if (EXCLUDED_API_PREFIXES.includes(head)) return null;
+    const sessionHash = await computeSessionHashFromHeaders(req.headers);
+    return { kind: "api", name: sub.slice(0, 200), sessionHash };
+  }
+
+  return null;
+};
+
+export async function middleware(req: NextRequest): Promise<NextResponse> {
+  try {
+    const event = await buildEvent(req);
+    if (event) {
+      // Fire-and-forget. Analytics never blocks the actual response.
+      // trackEvent swallows its own errors but we add a defensive catch in
+      // case a future change ever lets one escape — middleware must not
+      // produce unhandled rejections.
+      trackEvent(event).catch(() => {});
+    }
+  } catch {
+    // never block on analytics
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/", "/api/v1/:path*"],
+};

--- a/dify-helm-watchdog/src/test/api/v1/analytics.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/analytics.test.ts
@@ -1,0 +1,66 @@
+import { GET } from "@/app/api/v1/analytics/route";
+import { queryAnalytics } from "@/lib/analytics/track";
+
+jest.mock("@/lib/analytics/track", () => ({
+  queryAnalytics: jest.fn(),
+}));
+
+const mockedQuery = queryAnalytics as jest.MockedFunction<typeof queryAnalytics>;
+
+describe("GET /api/v1/analytics", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const sample = {
+    window: "7d" as const,
+    generatedAt: "2026-05-09T00:00:00.000Z",
+    mcp: { total: 10, uv: 4, byName: [{ name: "list_versions", hits: 10 }] },
+    api: { total: 20, uv: 6, byName: [{ name: "versions", hits: 20 }] },
+    page: { total: 33, uv: 12, byName: [] },
+  };
+
+  it("defaults to 7d window when no param is provided", async () => {
+    mockedQuery.mockResolvedValueOnce(sample);
+    const response = await GET(new Request("http://localhost/api/v1/analytics"));
+    expect(response.status).toBe(200);
+    expect(mockedQuery).toHaveBeenCalledWith("7d");
+    const body = await response.json();
+    expect(body).toEqual(sample);
+  });
+
+  it.each(["7d", "30d", "90d"])("accepts window=%s", async (w) => {
+    mockedQuery.mockResolvedValueOnce({ ...sample, window: w as never });
+    const response = await GET(
+      new Request(`http://localhost/api/v1/analytics?window=${w}`),
+    );
+    expect(response.status).toBe(200);
+    expect(mockedQuery).toHaveBeenCalledWith(w);
+  });
+
+  it("falls back to 7d for invalid window", async () => {
+    mockedQuery.mockResolvedValueOnce(sample);
+    const response = await GET(
+      new Request("http://localhost/api/v1/analytics?window=999d"),
+    );
+    expect(response.status).toBe(200);
+    expect(mockedQuery).toHaveBeenCalledWith("7d");
+  });
+
+  it("returns 502 when the worker query fails", async () => {
+    mockedQuery.mockRejectedValueOnce(new Error("upstream boom"));
+    const response = await GET(new Request("http://localhost/api/v1/analytics"));
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as { error: { status: string; message: string } };
+    expect(body.error.status).toBe("UNAVAILABLE");
+    expect(body.error.message).toContain("upstream boom");
+  });
+
+  it("sets edge cache headers on success", async () => {
+    mockedQuery.mockResolvedValueOnce(sample);
+    const response = await GET(new Request("http://localhost/api/v1/analytics"));
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, s-maxage=300, stale-while-revalidate=900",
+    );
+  });
+});

--- a/dify-helm-watchdog/src/test/api/v1/cron.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/cron.test.ts
@@ -260,7 +260,7 @@ describe("POST /api/v1/cron", () => {
 
   it("should handle MissingBlobTokenError gracefully", async () => {
     mockedSyncHelmData.mockRejectedValueOnce(
-      new MissingBlobTokenError("Blob storage token is not configured"),
+      new MissingBlobTokenError(),
     );
 
     const request = new Request("http://localhost/api/v1/cron", {

--- a/dify-helm-watchdog/src/test/lib/analytics/session.test.ts
+++ b/dify-helm-watchdog/src/test/lib/analytics/session.test.ts
@@ -1,0 +1,65 @@
+import { computeSessionHashFromHeaders } from "@/lib/analytics/session";
+
+describe("computeSessionHashFromHeaders", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.ANALYTICS_SESSION_SALT = "test-salt";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("produces a stable 64-char hex hash for the same headers", async () => {
+    const headers = new Headers({
+      "x-forwarded-for": "1.2.3.4",
+      "user-agent": "mcp-client/1.0",
+    });
+    const a = await computeSessionHashFromHeaders(headers);
+    const b = await computeSessionHashFromHeaders(headers);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("changes when the IP changes", async () => {
+    const ua = "mcp-client/1.0";
+    const a = await computeSessionHashFromHeaders(
+      new Headers({ "x-forwarded-for": "1.1.1.1", "user-agent": ua }),
+    );
+    const b = await computeSessionHashFromHeaders(
+      new Headers({ "x-forwarded-for": "2.2.2.2", "user-agent": ua }),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when the salt rotates", async () => {
+    const headers = new Headers({
+      "x-forwarded-for": "1.1.1.1",
+      "user-agent": "x",
+    });
+    const before = await computeSessionHashFromHeaders(headers);
+    process.env.ANALYTICS_SESSION_SALT = "different-salt";
+    const after = await computeSessionHashFromHeaders(headers);
+    expect(before).not.toBe(after);
+  });
+
+  it("falls back to 0.0.0.0 when no IP header is present", async () => {
+    const headers = new Headers({ "user-agent": "x" });
+    const a = await computeSessionHashFromHeaders(headers);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("uses the first IP from x-forwarded-for chain", async () => {
+    const headers = new Headers({
+      "x-forwarded-for": "5.5.5.5, 10.0.0.1, 10.0.0.2",
+      "user-agent": "x",
+    });
+    const a = await computeSessionHashFromHeaders(headers);
+    const single = await computeSessionHashFromHeaders(
+      new Headers({ "x-forwarded-for": "5.5.5.5", "user-agent": "x" }),
+    );
+    expect(a).toBe(single);
+  });
+});

--- a/dify-helm-watchdog/src/test/lib/analytics/track.test.ts
+++ b/dify-helm-watchdog/src/test/lib/analytics/track.test.ts
@@ -1,0 +1,148 @@
+import { createHmac } from "node:crypto";
+
+import { trackEvent, queryAnalytics } from "@/lib/analytics/track";
+
+describe("trackEvent", () => {
+  const originalEnv = process.env;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(null, { status: 202 }));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    fetchSpy.mockRestore();
+  });
+
+  it("is a no-op when env vars are missing", async () => {
+    delete process.env.ANALYTICS_WORKER_URL;
+    delete process.env.ANALYTICS_WORKER_SECRET;
+    await trackEvent({ kind: "api", name: "versions", sessionHash: "h" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts to /track with HMAC headers when configured", async () => {
+    process.env.ANALYTICS_WORKER_URL = "https://analytics.example.com";
+    process.env.ANALYTICS_WORKER_SECRET = "secret";
+
+    await trackEvent({
+      kind: "mcp",
+      name: "list_versions",
+      sessionHash: "abc",
+      latencyMs: 12.3,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://analytics.example.com/track");
+    expect(init.method).toBe("POST");
+
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    const ts = headers.get("X-Timestamp");
+    const sig = headers.get("X-Signature");
+    expect(ts).toBeTruthy();
+    expect(sig).toMatch(/^[a-f0-9]{64}$/);
+
+    // Body shape + signature correctness
+    const body = init.body as string;
+    const expected = createHmac("sha256", "secret")
+      .update(`${ts}.${body}`)
+      .digest("hex");
+    expect(sig).toBe(expected);
+
+    const parsed = JSON.parse(body);
+    expect(parsed).toMatchObject({
+      kind: "mcp",
+      name: "list_versions",
+      sessionHash: "abc",
+      latencyMs: 12,
+    });
+  });
+
+  it("strips trailing slashes from the worker URL", async () => {
+    process.env.ANALYTICS_WORKER_URL = "https://analytics.example.com///";
+    process.env.ANALYTICS_WORKER_SECRET = "secret";
+
+    await trackEvent({ kind: "page", name: "home", sessionHash: "h" });
+
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    expect(url).toBe("https://analytics.example.com/track");
+  });
+
+  it("swallows network errors", async () => {
+    process.env.ANALYTICS_WORKER_URL = "https://analytics.example.com";
+    process.env.ANALYTICS_WORKER_SECRET = "secret";
+    fetchSpy.mockRejectedValueOnce(new Error("network down"));
+
+    await expect(
+      trackEvent({ kind: "api", name: "versions", sessionHash: "h" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("clamps very long names to 256 chars", async () => {
+    process.env.ANALYTICS_WORKER_URL = "https://analytics.example.com";
+    process.env.ANALYTICS_WORKER_SECRET = "secret";
+
+    const longName = "x".repeat(500);
+    await trackEvent({ kind: "api", name: longName, sessionHash: "h" });
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const parsed = JSON.parse(init.body as string);
+    expect(parsed.name).toHaveLength(256);
+  });
+});
+
+describe("queryAnalytics", () => {
+  const originalEnv = process.env;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.ANALYTICS_WORKER_URL = "https://analytics.example.com";
+    process.env.ANALYTICS_WORKER_SECRET = "secret";
+    fetchSpy = jest.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    fetchSpy.mockRestore();
+  });
+
+  it("posts to /query and returns parsed payload", async () => {
+    const payload = {
+      window: "7d",
+      generatedAt: "2026-05-09T00:00:00Z",
+      mcp: { total: 10, uv: 3, byName: [{ name: "list_versions", hits: 10 }] },
+      api: { total: 5, uv: 2, byName: [] },
+      page: { total: 7, uv: 4, byName: [] },
+    };
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), { status: 200 }),
+    );
+
+    const result = await queryAnalytics("7d");
+    expect(result).toEqual(payload);
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://analytics.example.com/query");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ window: "7d" });
+  });
+
+  it("throws when worker is not configured", async () => {
+    delete process.env.ANALYTICS_WORKER_URL;
+    await expect(queryAnalytics("7d")).rejects.toThrow(/not configured/);
+  });
+
+  it("throws on non-2xx response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response("server error", { status: 500 }),
+    );
+    await expect(queryAnalytics("30d")).rejects.toThrow(/analytics query failed: 500/);
+  });
+});

--- a/dify-helm-watchdog/src/test/middleware.test.ts
+++ b/dify-helm-watchdog/src/test/middleware.test.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+
+import { middleware } from "@/middleware";
+import { trackEvent } from "@/lib/analytics/track";
+
+jest.mock("@/lib/analytics/track", () => ({
+  trackEvent: jest.fn(() => Promise.resolve()),
+}));
+
+const mockedTrack = trackEvent as jest.MockedFunction<typeof trackEvent>;
+
+const flushMicrotasks = () => new Promise((r) => setImmediate(r));
+
+const buildReq = (path: string, headers: Record<string, string> = {}) => {
+  return new NextRequest(`http://localhost${path}`, {
+    headers: {
+      "x-forwarded-for": "1.2.3.4",
+      "user-agent": "test-agent",
+      ...headers,
+    },
+  });
+};
+
+describe("middleware", () => {
+  beforeEach(() => {
+    process.env.ANALYTICS_SESSION_SALT = "test";
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("tracks homepage as kind=page name=home", async () => {
+    await middleware(buildReq("/"));
+    await flushMicrotasks();
+    expect(mockedTrack).toHaveBeenCalledTimes(1);
+    expect(mockedTrack.mock.calls[0][0]).toMatchObject({
+      kind: "page",
+      name: "home",
+    });
+    expect(mockedTrack.mock.calls[0][0].sessionHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("tracks v1 API endpoint as kind=api with the path tail", async () => {
+    await middleware(buildReq("/api/v1/versions/3.9.0/values"));
+    await flushMicrotasks();
+    expect(mockedTrack).toHaveBeenCalledTimes(1);
+    expect(mockedTrack.mock.calls[0][0]).toMatchObject({
+      kind: "api",
+      name: "versions/3.9.0/values",
+    });
+  });
+
+  it.each(["cron", "mcp", "sse", "analytics"])(
+    "skips /api/v1/%s (already instrumented or non-user)",
+    async (prefix) => {
+      await middleware(buildReq(`/api/v1/${prefix}`));
+      await middleware(buildReq(`/api/v1/${prefix}/foo`));
+      await flushMicrotasks();
+      expect(mockedTrack).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not track unrelated paths", async () => {
+    await middleware(buildReq("/dashboard"));
+    await middleware(buildReq("/swagger"));
+    await flushMicrotasks();
+    expect(mockedTrack).not.toHaveBeenCalled();
+  });
+
+  it("never throws even if trackEvent rejects", async () => {
+    mockedTrack.mockRejectedValueOnce(new Error("boom"));
+    await expect(middleware(buildReq("/"))).resolves.toBeDefined();
+  });
+});

--- a/dify-helm-watchdog/src/test/values-wizard.test.ts
+++ b/dify-helm-watchdog/src/test/values-wizard.test.ts
@@ -15,7 +15,7 @@ const readFixture = (relativePath: string) => {
 };
 
 type ImageMap = Record<string, { repository?: string; tag?: string }>;
-type HelmImageConfig = { image?: { repository?: string; tag?: string } };
+type HelmImageConfig = { image?: { repository?: string; tag?: string }; logoConfig?: { image?: { repository?: string; tag?: string } } };
 type HelmValuesMap = Record<string, HelmImageConfig>;
 
 describe("values wizard", () => {
@@ -35,7 +35,7 @@ describe("values wizard", () => {
 
       expect(changes.length).toBeGreaterThan(0);
       expect(changes.some((c) => c.status === "missing")).toBe(false);
-      expect(parsed.api.image.tag).toBe(images.api?.tag);
+      expect(parsed.api.image!.tag).toBe(images.api?.tag);
       Object.keys(templateParsed).forEach((key) => {
         expect(parsed).toHaveProperty(key);
       });
@@ -128,18 +128,18 @@ describe("values wizard", () => {
 
       expect(changes.length).toBeGreaterThan(0);
       expect(changes.some((c) => c.status === "missing")).toBe(false);
-      expect(parsed.api.image.tag).toBe(expectedTags.api);
-      expect(parsed.web.image.tag).toBe(expectedTags.web);
-      expect(parsed.sandbox.image.tag).toBe(expectedTags.sandbox);
-      expect(parsed.enterprise.image.tag).toBe(expectedTags.enterprise);
-      expect(parsed.web.logoConfig.image.tag).toBe(expectedTags.logo);
-      expect(parsed.api.image.repository).toBe(
+      expect(parsed.api.image!.tag).toBe(expectedTags.api);
+      expect(parsed.web.image!.tag).toBe(expectedTags.web);
+      expect(parsed.sandbox.image!.tag).toBe(expectedTags.sandbox);
+      expect(parsed.enterprise.image!.tag).toBe(expectedTags.enterprise);
+      expect(parsed.web.logoConfig!.image!.tag).toBe(expectedTags.logo);
+      expect(parsed.api.image!.repository).toBe(
         "registry.internal.example.com/dify/dify-api",
       );
-      expect(parsed.web.image.repository).toBe(
+      expect(parsed.web.image!.repository).toBe(
         "registry.internal.example.com/dify/dify-web",
       );
-      expect(parsed.sandbox.image.repository).toBe(
+      expect(parsed.sandbox.image!.repository).toBe(
         "registry.internal.example.com/dify/dify-sandbox",
       );
       Object.keys(templateParsed).forEach((key) => {


### PR DESCRIPTION
## Summary

- New public `/dashboard` page showing three symmetric panels: MCP tool calls, REST API requests, and homepage page views — each with total, top-5 breakdown, and a HyperLogLog unique-visitor estimate. 7d / 30d / 90d window toggle.
- All events flow to a new Cloudflare Worker (`cloudflare/analytics-worker/`) that writes to Cloudflare Analytics Engine (free tier: 10M writes / 1M reads per month). Vercel Blob is left alone — no migration in this PR.
- Vercel side: `src/middleware.ts` instruments `/` and `/api/v1/*` (excluding cron/mcp/sse/analytics); MCP handler wraps `executeTool()` with timing and fires its own track events. All tracking is fire-and-forget and never blocks the actual response.
- Privacy: no raw IPs, user agents, or request bodies stored. Session ID is `sha256(ip + user-agent + ANALYTICS_SESSION_SALT)`.

## Architecture

```
Vercel (Next.js)                          Cloudflare
  middleware.ts ─────────► /track ───►  Worker ──► Analytics Engine
  mcp/handler.ts ─────────► /track ───►          (dataset:
  /dashboard ◄─ /api/v1/analytics ──► /query ──►   dify_watchdog_events)
```

The Worker is a separate backend (no UI) deployed at `analytics.helm-watchdog.dify.ai`. Wrangler config + setup checklist are in `cloudflare/analytics-worker/wrangler.toml` comments.

## What you need to do after merge

1. `cd cloudflare/analytics-worker && wrangler deploy`
2. CF Dashboard → Workers → `dify-watchdog-analytics` → Custom Domains → add `analytics.helm-watchdog.dify.ai`
3. `wrangler secret put ANALYTICS_WORKER_SECRET / CF_ACCOUNT_ID / CF_ANALYTICS_TOKEN`
4. Add `ANALYTICS_WORKER_URL`, `ANALYTICS_WORKER_SECRET`, `ANALYTICS_SESSION_SALT` to Vercel env vars

If those env vars are unset, tracking is a no-op and `/dashboard` renders empty stats with a friendly error — the rest of the site is unaffected.

## Test plan

- [x] `yarn lint` clean (only pre-existing warnings in `markdown-renderer.tsx`)
- [x] `yarn test` — 4 new test suites, 28 new test cases, all green (`session.test.ts`, `track.test.ts`, `analytics.test.ts`, `middleware.test.ts`). One pre-existing `cron.test.ts` failure unrelated to this PR.
- [ ] Post-deploy smoke (see plan file): `wrangler tail` while hitting `/api/v1/versions`, MCP `tools/call`, and `/` — confirm three event kinds appear; open `/dashboard` and verify the cards render.

## Out of scope

- Vercel Blob → R2 migration (separate effort)
- Per-MCP-call argument logging
- Tab/version-level click tracking inside the SPA
- Dashboard auth (intentionally public)