### PR TITLE
Migrate cache storage from Vercel Blob to Cloudflare R2

### DIFF
--- a/.github/workflows/code_check.yml
+++ b/.github/workflows/code_check.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Build project
         run: yarn build
         env:
-          # 使用示例环境变量，构建时不需要实际的 Blob token
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN || 'dummy-token-for-build' }}
+          # CI builds run in local mode, so no R2 credentials are needed.
           ENABLE_LOCAL_MODE: 'true'
 
       - name: Check build output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**dify-helm-watchdog** is a Next.js application that monitors the [Dify Helm chart](https://langgenius.github.io/dify-helm) by taking daily snapshots of chart versions. It provides a cyber-dark themed dashboard and RESTful API for accessing Helm chart metadata, values.yaml files, Docker image lists, and image validation results. All artifacts are cached in Vercel Blob storage.
+**dify-helm-watchdog** is a Next.js application that monitors the [Dify Helm chart](https://langgenius.github.io/dify-helm) by taking daily snapshots of chart versions. It provides a cyber-dark themed dashboard and RESTful API for accessing Helm chart metadata, values.yaml files, Docker image lists, and image validation results. All artifacts are cached in Cloudflare R2 (S3-compatible) and served publicly through a custom domain.
 
 ## Development Commands
 
@@ -35,7 +35,11 @@ yarn start
 Required environment variables (copy from `.env.example`):
 
 ```bash
-BLOB_READ_WRITE_TOKEN="vercel_blob_rw_..." # Vercel Blob storage token
+R2_ACCOUNT_ID="..."                        # Cloudflare account ID
+R2_ACCESS_KEY_ID="..."                     # R2 S3 API token (Object Read & Write)
+R2_SECRET_ACCESS_KEY="..."
+R2_BUCKET="dify-helm-watchdog"             # Bucket name
+R2_PUBLIC_BASE_URL="https://dify-watchdog-blobs.langgenius.app" # Custom domain bound to the bucket
 CRON_API_KEY="..."                         # Optional: protects /api/v1/cron endpoint
 
 # Analytics (optional — without these, tracking + /dashboard are no-ops)
@@ -44,7 +48,7 @@ ANALYTICS_WORKER_SECRET="..."              # HMAC secret, must match the Cloudfl
 ANALYTICS_SESSION_SALT="..."               # salts sha256(ip + ua + salt) for the session hash
 ```
 
-Create `.env.local` for local development. The cron endpoint requires the blob token even in development. The three analytics vars can be omitted locally; with them unset, `trackEvent()` is a no-op and `/dashboard` shows empty stats — the rest of the app is unaffected.
+Create `.env.local` for local development. The cron endpoint requires the R2 credentials in production; for local development you can either set them or use `ENABLE_LOCAL_MODE=true` to fall back to filesystem storage under `.cache/helm/`. The three analytics vars can be omitted locally; with them unset, `trackEvent()` is a no-op and `/dashboard` shows empty stats — the rest of the app is unaffected.
 
 ## Architecture
 
@@ -61,11 +65,11 @@ syncHelmData() in lib/helm.ts
   ├─ Extract docker-images.yaml
   └─ Validate Docker images exist in registries
   ↓
-Store in Vercel Blob
+Store in Cloudflare R2 (helm-watchdog/ prefix)
   ├─ cache.json (version metadata, hashes)
   ├─ values/*.yaml
   ├─ images/*.yaml
-  └─ validation/*.json
+  └─ image-validation/*.json
   ↓
 Next.js UI + REST API + MCP Endpoints
 ```
@@ -124,7 +128,7 @@ yarn test
 Tests follow the `src/test/api/v1/` structure matching the API routes. Each test file mocks:
 - `@/lib/helm` (loadCache, syncHelmData)
 - `next/cache` (revalidatePath)
-- Global `fetch` for blob storage requests
+- Global `fetch` for R2 object reads (URLs are publicly fetchable via the custom domain)
 
 Key test patterns:
 - All tests use `beforeEach`/`afterEach` for mock cleanup
@@ -174,7 +178,7 @@ The validation pipeline (in `lib/validation.ts`):
    - Detect registry (Docker Hub, GHCR)
    - Query manifest API for all platforms (linux/amd64, linux/arm64, etc.)
    - Record found/missing status with digest
-3. Store validation results as JSON in blob storage
+3. Store validation results as JSON in R2
 4. Aggregate status: `ALL_FOUND`, `PARTIAL`, `MISSING`, `ERROR`
 
 Status aggregation is used in:
@@ -272,7 +276,7 @@ Deployment is configured via `vercel.json`:
 }
 ```
 
-The cron runs daily at 2am UTC. Ensure `BLOB_READ_WRITE_TOKEN` is configured in Vercel project settings.
+The cron runs daily at 2am UTC. Ensure the five `R2_*` environment variables are configured in Vercel project settings.
 
 ## Shell Scripts (Root Directory)
 
@@ -307,7 +311,7 @@ These scripts are independent utilities for manual inspection and were likely us
 
 ### Cache invalidation
 
-After updating blob storage, call:
+After updating R2, call:
 ```typescript
 import { revalidatePath } from 'next/cache';
 revalidatePath("/", "page"); // Invalidate homepage
@@ -315,7 +319,7 @@ revalidatePath("/", "page"); // Invalidate homepage
 
 ### Reading inline vs. fetched content
 
-Version metadata includes both inline content (for quick access) and blob URLs:
+Version metadata includes both inline content (for quick access) and public R2 URLs:
 
 ```typescript
 const version = cache.versions.find(v => v.version === "1.0.0");

--- a/dify-helm-watchdog/.env.example
+++ b/dify-helm-watchdog/.env.example
@@ -1,4 +1,13 @@
-BLOB_READ_WRITE_TOKEN="vercel_blob_rw_vExxxxxxxxxxxxZ"
+# Cloudflare R2 (S3-compatible) — backs the cache.json + per-version artifacts.
+# All five vars are required in production. The bucket must expose a public
+# custom domain (R2_PUBLIC_BASE_URL) so the URLs stored in cache.json are
+# directly fetchable by clients.
+R2_ACCOUNT_ID="your-cloudflare-account-id"
+R2_ACCESS_KEY_ID="your-r2-s3-api-token-access-key"
+R2_SECRET_ACCESS_KEY="your-r2-s3-api-token-secret"
+R2_BUCKET="dify-helm-watchdog"
+R2_PUBLIC_BASE_URL="https://dify-watchdog-blobs.langgenius.app"
+
 CRON_API_KEY=xxxxxx
 
 # Cloudflare-backed analytics (see /dashboard).

--- a/dify-helm-watchdog/README.md
+++ b/dify-helm-watchdog/README.md
@@ -1,11 +1,11 @@
 # dify-helm-watchdog
 
-Cyber-dark dashboard that snapshots the [Dify Helm chart](https://langgenius.github.io/dify-helm) every day. A scheduled Vercel Cron job downloads new chart versions, extracts `values.yaml` and a curated `docker-images.yaml`, caches both artifacts in Vercel Blob storage, and exposes them through a Tailwind + shadcn styled Next.js UI.
+Cyber-dark dashboard that snapshots the [Dify Helm chart](https://langgenius.github.io/dify-helm) every day. A scheduled Vercel Cron job downloads new chart versions, extracts `values.yaml` and a curated `docker-images.yaml`, caches both artifacts in Cloudflare R2, and exposes them through a Tailwind + shadcn styled Next.js UI.
 
 ## Features
 
 - **Daily cron** via `/api/v1/cron` (configured in `vercel.json`) keeps `cache.json`, `values.yaml`, and `docker-images.yaml` files fresh.
-- **Vercel Blob storage** persists cached artifacts; hashes are tracked in `cache.json` for quick diffing.
+- **Cloudflare R2** persists cached artifacts via the S3-compatible API, served publicly through a custom domain; hashes are tracked in `cache.json` for quick diffing.
 - **Cyber dark UI** with a left-hand version rail and dual copyable code panes powered by a shadcn-inspired `CodeBlock`.
 - **Public usage dashboard** at `/dashboard` showing MCP / REST / page-view counts plus top countries, backed by a Cloudflare Worker + Analytics Engine (no IPs, UAs, or bodies stored — only a hashed session ID and a derived country code).
 - **RESTful API** for programmatic access:
@@ -24,7 +24,7 @@ Cyber-dark dashboard that snapshots the [Dify Helm chart](https://langgenius.git
 
 - Node.js 20+
 - Yarn (project uses `yarn.lock`)
-- Vercel account with Blob storage enabled
+- Vercel account (deployment) and Cloudflare account with an R2 bucket + S3 API token
 
 ## Local Setup
 
@@ -36,9 +36,9 @@ Cyber-dark dashboard that snapshots the [Dify Helm chart](https://langgenius.git
 2. Configure environment variables:
    ```bash
    cp .env.example .env.local
-   # Edit .env.local and set BLOB_READ_WRITE_TOKEN
+   # Edit .env.local and set the R2_* variables
    ```
-   Create a token with `vercel storage ls` or the Vercel dashboard. The cron endpoint requires this token even in development.
+   Create an R2 bucket in the Cloudflare dashboard, then generate an S3 API token (Object Read & Write) scoped to that bucket. Attach a public custom domain and use it as `R2_PUBLIC_BASE_URL`. To skip R2 entirely during local development, set `ENABLE_LOCAL_MODE=true` and the cache will be written under `.cache/helm/` instead.
 
 3. Run the dev server:
    ```bash
@@ -54,7 +54,7 @@ Cyber-dark dashboard that snapshots the [Dify Helm chart](https://langgenius.git
 ## Deployment Notes
 
 - `vercel.json` schedules the cron at `0 2 * * *` UTC. Adjust as needed.
-- Ensure `BLOB_READ_WRITE_TOKEN` (or project level Vercel Blob integration) is configured in the Vercel project settings.
+- Ensure the five `R2_*` variables (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_PUBLIC_BASE_URL`) are configured in the Vercel project settings.
 - No additional build steps are required; the cron uses Next.js App Router API routes.
 
 ## Development Commands
@@ -70,7 +70,7 @@ Cyber-dark dashboard that snapshots the [Dify Helm chart](https://langgenius.git
 
 ```
 ┌────────────┐      ┌───────────────────────────┐      ┌─────────────────┐
-│ Vercel Cron│ ---> │ /api/v1/cron (syncHelmData)  │ ---> │ Vercel Blob     │
+│ Vercel Cron│ ---> │ /api/v1/cron (syncHelmData)  │ ---> │ Cloudflare R2   │
 └────────────┘      │ - fetch index.yaml        │      │ cache.json       │
                     │ - extract values/images   │      │ values/*.yaml    │
                     └───────────────────────────┘      │ images/*.yaml    │

--- a/dify-helm-watchdog/UT-spec-description.md
+++ b/dify-helm-watchdog/UT-spec-description.md
@@ -163,8 +163,8 @@ This document describes the comprehensive unit test coverage for the dify-helm-w
     - **Validates:** Skip detection and reporting
 
 **Error Handling:**
-11. **MissingBlobTokenError**
-    - **Scenario:** Blob storage token not configured
+11. **MissingStorageCredentialsError**
+    - **Scenario:** R2 credentials not configured
     - **Expected:** Returns friendly error message, status=failed
     - **Validates:** Custom error handling
 
@@ -335,7 +335,7 @@ This document describes the comprehensive unit test coverage for the dify-helm-w
 **Data Fetching:**
 7. **Fetch From URL**
    - **Scenario:** Inline content not available
-   - **Expected:** Fetches from blob URL
+   - **Expected:** Fetches from R2 URL
    - **Validates:** HTTP fetch call, URL usage
 
 8. **Fetch Failure**
@@ -399,7 +399,7 @@ This document describes the comprehensive unit test coverage for the dify-helm-w
 
 4. **Fetch From URL**
    - **Scenario:** Inline not available
-   - **Expected:** Fetches from blob URL
+   - **Expected:** Fetches from R2 URL
    - **Validates:** HTTP fetch with correct URL
 
 5. **Fetch Failure**
@@ -450,7 +450,7 @@ This document describes the comprehensive unit test coverage for the dify-helm-w
 
 5. **Fetch From URL**
    - **Scenario:** Inline not available
-   - **Expected:** Fetches from blob URL, normalizes data
+   - **Expected:** Fetches from R2 URL, normalizes data
    - **Validates:** HTTP fetch, JSON parsing
 
 6. **Fetch Failure**
@@ -585,7 +585,7 @@ This document describes the comprehensive unit test coverage for the dify-helm-w
 1. **`@/lib/helm`**
    - `loadCache()`: Returns mock cache data
    - `syncHelmData()`: Simulates sync operations
-   - `MissingBlobTokenError`: Custom error class
+   - `MissingStorageCredentialsError`: Custom error class
 
 2. **`next/cache`**
    - `revalidatePath()`: Tracks ISR revalidation calls
@@ -799,7 +799,7 @@ All tests run quickly (< 5 seconds typical) suitable for:
 4. **Mock Data Drift:** Mock data may diverge from actual production data structure
 
 ### Suggested Improvements
-1. **Integration Tests:** Add tests with real cache files and blob storage
+1. **Integration Tests:** Add tests with real cache files and R2 storage
 2. **Snapshot Testing:** Use Jest snapshots for complex response structures
 3. **Coverage Reporting:** Enable and enforce minimum coverage thresholds
 4. **Property-Based Testing:** Use libraries like `fast-check` for edge case discovery

--- a/dify-helm-watchdog/package.json
+++ b/dify-helm-watchdog/package.json
@@ -11,10 +11,10 @@
     "test": "jest"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1046.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
-    "@vercel/blob": "2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.24",

--- a/dify-helm-watchdog/src/app/api/cron/route.ts
+++ b/dify-helm-watchdog/src/app/api/cron/route.ts
@@ -1,6 +1,6 @@
 import { revalidatePath } from "next/cache";
 import {
-  MissingBlobTokenError,
+  MissingStorageCredentialsError,
   type SyncResult,
   syncHelmData,
 } from "@/lib/helm";
@@ -145,7 +145,7 @@ const createStreamResponse = (request: Request) => {
       } catch (error) {
         statusLine = "[status] failed";
 
-        if (error instanceof MissingBlobTokenError) {
+        if (error instanceof MissingStorageCredentialsError) {
           write(`[error] ${error.message}`);
         } else if (error instanceof Error) {
           write(`[error] ${error.message}`);

--- a/dify-helm-watchdog/src/app/api/v1/cron/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/cron/route.ts
@@ -1,7 +1,7 @@
 import { revalidatePath } from "next/cache";
 import { createErrorResponse } from "@/lib/api/response";
 import {
-  MissingBlobTokenError,
+  MissingStorageCredentialsError,
   type SyncResult,
   syncHelmData,
 } from "@/lib/helm";
@@ -237,7 +237,7 @@ const createStreamResponse = (request: Request) => {
       } catch (error) {
         statusLine = "[status] failed";
 
-        if (error instanceof MissingBlobTokenError) {
+        if (error instanceof MissingStorageCredentialsError) {
           write(`[error] ${error.message}`);
         } else if (error instanceof Error) {
           write(`[error] ${error.message}`);

--- a/dify-helm-watchdog/src/lib/helm.ts
+++ b/dify-helm-watchdog/src/lib/helm.ts
@@ -16,8 +16,6 @@ import type {
   StoredAsset,
   StoredVersion,
 } from "./types";
-import { MissingStorageCredentialsError } from "./storage-errors";
-
 export { MissingStorageCredentialsError } from "./storage-errors";
 import {
   HELM_INDEX_URL,
@@ -962,10 +960,9 @@ export const loadCache = async (): Promise<CachePayload | null> => {
     // In development: reads from local file system
     return enrichWithInlineContent(sanitizedRemote);
   } catch (error) {
-    if (error instanceof MissingStorageCredentialsError) {
-      throw error;
-    }
-
+    // Missing storage credentials are tolerated here so prerender / preview
+    // builds without R2 env vars still succeed (page renders empty state).
+    // Cron paths surface the same error explicitly via ensureStorageAccess().
     console.error("[helm-cache] Failed to load cache", error);
     return null;
   }

--- a/dify-helm-watchdog/src/lib/helm.ts
+++ b/dify-helm-watchdog/src/lib/helm.ts
@@ -16,6 +16,9 @@ import type {
   StoredAsset,
   StoredVersion,
 } from "./types";
+import { MissingStorageCredentialsError } from "./storage-errors";
+
+export { MissingStorageCredentialsError } from "./storage-errors";
 import {
   HELM_INDEX_URL,
   HELM_REPO_BASE,
@@ -296,15 +299,7 @@ export interface SyncOptions {
   forceVersions?: string[];
 }
 
-export class MissingBlobTokenError extends Error {
-  constructor() {
-    super(
-      "BLOB_READ_WRITE_TOKEN is not configured. Please create a Vercel Blob store and expose the token before triggering the cron job.",
-    );
-  }
-}
-
-const ensureBlobAccess = async (): Promise<void> => {
+const ensureStorageAccess = async (): Promise<void> => {
   return await storage.ensureAccess();
 };
 
@@ -967,7 +962,7 @@ export const loadCache = async (): Promise<CachePayload | null> => {
     // In development: reads from local file system
     return enrichWithInlineContent(sanitizedRemote);
   } catch (error) {
-    if (error instanceof MissingBlobTokenError) {
+    if (error instanceof MissingStorageCredentialsError) {
       throw error;
     }
 
@@ -1014,7 +1009,7 @@ export const syncHelmData = async (
 ): Promise<SyncResult> => {
   const log = options.log ?? (() => {});
 
-  await ensureBlobAccess();
+  await ensureStorageAccess();
 
   const forcedVersions = new Set(
     (options.forceVersions ?? [])

--- a/dify-helm-watchdog/src/lib/storage-errors.ts
+++ b/dify-helm-watchdog/src/lib/storage-errors.ts
@@ -1,0 +1,11 @@
+export class MissingStorageCredentialsError extends Error {
+  constructor(missing?: readonly string[]) {
+    const detail = missing && missing.length > 0
+      ? ` Missing: ${missing.join(", ")}.`
+      : "";
+    super(
+      `Storage credentials are not configured. Please set the R2_* environment variables before triggering the cron job.${detail}`,
+    );
+    this.name = "MissingStorageCredentialsError";
+  }
+}

--- a/dify-helm-watchdog/src/lib/types.ts
+++ b/dify-helm-watchdog/src/lib/types.ts
@@ -72,7 +72,7 @@ export interface HeadResult {
   size: number;
   uploadedAt: Date;
   downloadedAt?: Date;
-  downloadUrl?: string; // For compatibility with Vercel Blob
+  downloadUrl?: string;
 }
 
 export interface Storage {

--- a/dify-helm-watchdog/src/services/storage.ts
+++ b/dify-helm-watchdog/src/services/storage.ts
@@ -1,55 +1,118 @@
 import path from "node:path";
 import crypto from "node:crypto";
-import { BlobNotFoundError, head, put } from "@vercel/blob";
+import {
+  HeadObjectCommand,
+  NotFound,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import type { HeadResult, Storage, StoredAsset } from "../lib/types";
 import { LOCAL_CACHE_DIR_RELATIVE } from "../constants/helm";
+import { MissingStorageCredentialsError } from "../lib/storage-errors";
 
-// Custom error for missing blob token
-class MissingBlobTokenError extends Error {
-  constructor() {
-    super(
-      "BLOB_READ_WRITE_TOKEN or VERCEL_BLOB_RW_TOKEN environment variable is required for local development",
-    );
-    this.name = "MissingBlobTokenError";
-  }
-}
+const R2_ENV_VARS = [
+  "R2_ACCOUNT_ID",
+  "R2_ACCESS_KEY_ID",
+  "R2_SECRET_ACCESS_KEY",
+  "R2_BUCKET",
+  "R2_PUBLIC_BASE_URL",
+] as const;
 
-// Helper function to get local asset path - always uses absolute paths
 const getLocalAssetPath = (assetPath: string): string => {
-  // Remove 'helm-watchdog/' prefix if present to avoid path duplication
   const relativePath = assetPath.replace(/^helm-watchdog\//, "");
   return path.join(process.cwd(), LOCAL_CACHE_DIR_RELATIVE, relativePath);
 };
 
-// Helper function to compute hash
 const computeHash = (input: string): string =>
   crypto.createHash("sha256").update(input).digest("hex");
 
-// Blob storage implementation
-export class BlobStorageService implements Storage {
-  async ensureAccess(): Promise<void> {
-    if (process.env.BLOB_READ_WRITE_TOKEN || process.env.VERCEL_BLOB_RW_TOKEN) {
-      return;
+const stripTrailingSlash = (value: string): string =>
+  value.endsWith("/") ? value.slice(0, -1) : value;
+
+export class R2StorageService implements Storage {
+  private client: S3Client | null = null;
+  private bucket: string | null = null;
+  private publicBaseUrl: string | null = null;
+
+  private resolveConfig(): {
+    accountId: string;
+    accessKeyId: string;
+    secretAccessKey: string;
+    bucket: string;
+    publicBaseUrl: string;
+  } {
+    const missing = R2_ENV_VARS.filter((name) => !process.env[name]);
+    if (missing.length > 0) {
+      throw new MissingStorageCredentialsError(missing);
     }
 
-    // When deployed on Vercel the token is injected automatically, but in local dev we need a safeguard.
-    if (!process.env.VERCEL) {
-      throw new MissingBlobTokenError();
-    }
+    return {
+      accountId: process.env.R2_ACCOUNT_ID as string,
+      accessKeyId: process.env.R2_ACCESS_KEY_ID as string,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY as string,
+      bucket: process.env.R2_BUCKET as string,
+      publicBaseUrl: stripTrailingSlash(process.env.R2_PUBLIC_BASE_URL as string),
+    };
   }
 
-  async read(path: string): Promise<HeadResult | null> {
+  private getClient(): S3Client {
+    if (this.client && this.bucket && this.publicBaseUrl) {
+      return this.client;
+    }
+
+    const config = this.resolveConfig();
+    this.bucket = config.bucket;
+    this.publicBaseUrl = config.publicBaseUrl;
+    this.client = new S3Client({
+      region: "auto",
+      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+    });
+    return this.client;
+  }
+
+  private buildPublicUrl(key: string): string {
+    if (!this.publicBaseUrl) throw new Error("R2 client not initialized");
+    return `${this.publicBaseUrl}/${key}`;
+  }
+
+  async ensureAccess(): Promise<void> {
+    // On Vercel the env vars must be present; locally we let LocalStorageService
+    // take over via the factory, so the error is only meaningful on Vercel.
+    if (!process.env.VERCEL) {
+      // Allow missing credentials in local dev — only validate when credentials are partially set.
+      const present = R2_ENV_VARS.filter((name) => Boolean(process.env[name]));
+      if (present.length === 0) return;
+    }
+    this.resolveConfig();
+  }
+
+  async read(assetPath: string): Promise<HeadResult | null> {
+    const client = this.getClient();
     try {
-      const metadata = await head(path);
+      const result = await client.send(
+        new HeadObjectCommand({ Bucket: this.bucket as string, Key: assetPath }),
+      );
+      const url = this.buildPublicUrl(assetPath);
       return {
-        url: metadata.url,
-        pathname: metadata.pathname,
-        size: metadata.size,
-        uploadedAt: metadata.uploadedAt,
-        downloadUrl: metadata.url,
+        url,
+        pathname: assetPath,
+        size: result.ContentLength ?? 0,
+        uploadedAt: result.LastModified ?? new Date(),
+        downloadUrl: url,
       };
     } catch (error) {
-      if (error instanceof BlobNotFoundError) {
+      if (error instanceof NotFound) return null;
+      if (
+        error &&
+        typeof error === "object" &&
+        "$metadata" in error &&
+        (error as { $metadata?: { httpStatusCode?: number } }).$metadata
+          ?.httpStatusCode === 404
+      ) {
         return null;
       }
       throw error;
@@ -65,43 +128,49 @@ export class BlobStorageService implements Storage {
 
       if (!response.ok) {
         throw new Error(
-          `Failed to fetch blob content from ${url}: ${response.status} ${response.statusText}`,
+          `Failed to fetch R2 object from ${url}: ${response.status} ${response.statusText}`,
         );
       }
 
       return await response.text();
     } catch (error) {
-      console.error(`[helm-cache] Failed to fetch blob content from ${url}`, error);
+      console.error(`[helm-cache] Failed to fetch R2 object from ${url}`, error);
       throw error;
     }
   }
 
-  async write(path: string, content: string, contentType: string): Promise<StoredAsset> {
+  async write(
+    assetPath: string,
+    content: string,
+    contentType: string,
+  ): Promise<StoredAsset> {
+    const client = this.getClient();
     const hash = computeHash(content);
-    const result = await put(path, content, {
-      access: "public",
-      contentType,
-      addRandomSuffix: false,
-      allowOverwrite: true,
-    });
+
+    await client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket as string,
+        Key: assetPath,
+        Body: content,
+        ContentType: contentType,
+      }),
+    );
 
     return {
-      path: result.pathname,
-      url: result.url,
+      path: assetPath,
+      url: this.buildPublicUrl(assetPath),
       hash,
     };
   }
 }
 
-// Local storage implementation
 export class LocalStorageService implements Storage {
   async ensureAccess(): Promise<void> {
-    // Always allow access in local mode
     return;
   }
 
-  async read(path: string): Promise<HeadResult | null> {
-    const fullPath = getLocalAssetPath(path);
+  async read(assetPath: string): Promise<HeadResult | null> {
+    const fullPath = getLocalAssetPath(assetPath);
 
     try {
       const fs = await import("node:fs/promises");
@@ -109,14 +178,19 @@ export class LocalStorageService implements Storage {
 
       return {
         url: `file://${fullPath}`,
-        pathname: path,
+        pathname: assetPath,
         size: stats.size,
         uploadedAt: new Date(stats.mtime),
         downloadedAt: new Date(),
         downloadUrl: `file://${fullPath}`,
       };
     } catch (error) {
-      if (error && typeof error === "object" && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
         return null;
       }
       throw error;
@@ -128,34 +202,34 @@ export class LocalStorageService implements Storage {
       throw new Error(`Invalid local file URL: ${url}`);
     }
 
-    const filePath = url.slice(7); // Remove "file://" prefix
+    const filePath = url.slice(7);
     const fs = await import("node:fs/promises");
     return await fs.readFile(filePath, "utf-8");
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async write(path: string, content: string, _contentType: string): Promise<StoredAsset> {
-    const fullPath = getLocalAssetPath(path);
+  async write(
+    assetPath: string,
+    content: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _contentType: string,
+  ): Promise<StoredAsset> {
+    const fullPath = getLocalAssetPath(assetPath);
     const hash = computeHash(content);
 
     const fs = await import("node:fs/promises");
     const pathModule = await import("node:path");
 
-    // Ensure directory exists
     await fs.mkdir(pathModule.dirname(fullPath), { recursive: true });
-
-    // Write file
     await fs.writeFile(fullPath, content, "utf-8");
 
     return {
-      path,
+      path: assetPath,
       url: `file://${fullPath}`,
       hash,
     };
   }
 }
 
-// Storage factory
 export const createStorageService = (): Storage => {
   const isLocalMode = process.env.ENABLE_LOCAL_MODE === "true";
 
@@ -163,5 +237,5 @@ export const createStorageService = (): Storage => {
     return new LocalStorageService();
   }
 
-  return new BlobStorageService();
+  return new R2StorageService();
 };

--- a/dify-helm-watchdog/src/services/storage.ts
+++ b/dify-helm-watchdog/src/services/storage.ts
@@ -76,7 +76,8 @@ export class R2StorageService implements Storage {
 
   private buildPublicUrl(key: string): string {
     if (!this.publicBaseUrl) throw new Error("R2 client not initialized");
-    return `${this.publicBaseUrl}/${key}`;
+    const normalized = key.startsWith("/") ? key.slice(1) : key;
+    return `${this.publicBaseUrl}/${normalized}`;
   }
 
   async ensureAccess(): Promise<void> {
@@ -101,7 +102,9 @@ export class R2StorageService implements Storage {
         url,
         pathname: assetPath,
         size: result.ContentLength ?? 0,
-        uploadedAt: result.LastModified ?? new Date(),
+        // R2 always populates LastModified for existing objects; epoch sentinel
+        // makes any missing value visible rather than implying "just uploaded".
+        uploadedAt: result.LastModified ?? new Date(0),
         downloadUrl: url,
       };
     } catch (error) {

--- a/dify-helm-watchdog/src/test/api/v1/cron.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/cron.test.ts
@@ -1,15 +1,15 @@
 import { POST } from "@/app/api/v1/cron/route";
-import { syncHelmData, MissingBlobTokenError } from "@/lib/helm";
+import { syncHelmData, MissingStorageCredentialsError } from "@/lib/helm";
 import { revalidatePath } from "next/cache";
 
 jest.mock("@/lib/helm", () => ({
   syncHelmData: jest.fn(),
-  MissingBlobTokenError: class MissingBlobTokenError extends Error {
+  MissingStorageCredentialsError: class MissingStorageCredentialsError extends Error {
     constructor() {
       super(
-        "BLOB_READ_WRITE_TOKEN is not configured. Please create a Vercel Blob store and expose the token before triggering the cron job.",
+        "Storage credentials are not configured. Please set the R2_* environment variables before triggering the cron job.",
       );
-      this.name = "MissingBlobTokenError";
+      this.name = "MissingStorageCredentialsError";
     }
   },
 }));
@@ -260,9 +260,9 @@ describe("POST /api/v1/cron", () => {
     expect(text).toContain("[result] no new versions detected");
   });
 
-  it("should handle MissingBlobTokenError gracefully", async () => {
+  it("should handle MissingStorageCredentialsError gracefully", async () => {
     mockedSyncHelmData.mockRejectedValueOnce(
-      new MissingBlobTokenError(),
+      new MissingStorageCredentialsError(),
     );
 
     const request = new Request("http://localhost/api/v1/cron", {
@@ -277,7 +277,7 @@ describe("POST /api/v1/cron", () => {
     expect(response.status).toBe(200);
 
     const text = await streamToText(response);
-    expect(text).toContain("[error] BLOB_READ_WRITE_TOKEN is not configured");
+    expect(text).toContain("[error] Storage credentials are not configured");
     expect(text).toContain("[status] failed");
   });
 

--- a/dify-helm-watchdog/yarn.lock
+++ b/dify-helm-watchdog/yarn.lock
@@ -74,6 +74,461 @@
   resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
   integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
 
+"@aws-crypto/crc32@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-5.2.0.tgz#cfcc22570949c98c6689cfcbd2d693d36cdae2e1"
+  integrity sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/crc32c@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz#4e34aab7f419307821509a98b9b08e84e0c1917e"
+  integrity sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha1-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz#b0ee2d2821d3861f017e965ef3b4cb38e3b6a0f4"
+  integrity sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==
+  dependencies:
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
+  integrity sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==
+  dependencies:
+    "@aws-crypto/sha256-js" "^5.2.0"
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
+  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/supports-web-crypto@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz#a1e399af29269be08e695109aa15da0a07b5b5fb"
+  integrity sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-crypto/util@5.2.0", "@aws-crypto/util@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
+  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-s3@^3.1046.0":
+  version "3.1046.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.1046.0.tgz#7d4541a58d7eeaf6fb16c7e2b9a5267845ead46d"
+  integrity sha512-Cwl2SPm0CLczqNLEW2AZR9G/W+Jap85K7uUVOTRHzG3pErVeYRKOnbzsbAqGHnSYBdaxZ9a58YVaWj67P8tF4w==
+  dependencies:
+    "@aws-crypto/sha1-browser" "5.2.0"
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/credential-provider-node" "^3.972.40"
+    "@aws-sdk/middleware-bucket-endpoint" "^3.972.11"
+    "@aws-sdk/middleware-expect-continue" "^3.972.11"
+    "@aws-sdk/middleware-flexible-checksums" "^3.974.17"
+    "@aws-sdk/middleware-host-header" "^3.972.11"
+    "@aws-sdk/middleware-location-constraint" "^3.972.10"
+    "@aws-sdk/middleware-logger" "^3.972.10"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.12"
+    "@aws-sdk/middleware-sdk-s3" "^3.972.38"
+    "@aws-sdk/middleware-ssec" "^3.972.10"
+    "@aws-sdk/middleware-user-agent" "^3.972.39"
+    "@aws-sdk/region-config-resolver" "^3.972.14"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.26"
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/util-endpoints" "^3.996.9"
+    "@aws-sdk/util-user-agent-browser" "^3.972.11"
+    "@aws-sdk/util-user-agent-node" "^3.973.25"
+    "@smithy/core" "^3.24.1"
+    "@smithy/fetch-http-handler" "^5.4.1"
+    "@smithy/node-http-handler" "^4.7.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.974.9":
+  version "3.974.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.9.tgz#7030263245078a5e84bf575f45818a7a5ba0df0b"
+  integrity sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/xml-builder" "^3.972.23"
+    "@smithy/core" "^3.24.1"
+    "@smithy/signature-v4" "^5.4.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/crc64-nvme@^3.972.8":
+  version "3.972.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz#47e2ab559e881c0bdabff178a62ed4249f3fc1a8"
+  integrity sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.35":
+  version "3.972.35"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.35.tgz#a7a3e8a9b36ead5e5be1ece585add8596c71f5ee"
+  integrity sha512-WkFQ8BedszVomhh/Zzs8WwnE/XBmTqZjoQVB8u/4zH6kZCjouXZpPpb93gD8m0EZmzAl7dxHE/y+yDpuKzNCMw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.37":
+  version "3.972.37"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.37.tgz#c2457bcc2c1f85d542e4d56463333809a788e79a"
+  integrity sha512-ylx0ZJTU+2eNcvXQ69VNR3TVSYa/ibpvdK717/NxqR9aXRMn2QRWZaiI8aa5yY/fOWZ5mknSmxGaVxxtdwv3EA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/fetch-http-handler" "^5.4.1"
+    "@smithy/node-http-handler" "^4.7.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.39.tgz#9dd247ff984b20b167abf26db3fdc912bb0d5e98"
+  integrity sha512-QhRSrdkk+Gq0AFIylpiI0N6lcJqFYV9Jtr4Luz5FpYOYbjJSfyTG6iLhnK/UPIgN1Jnon8WAmSC//16XYGvwkA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/credential-provider-env" "^3.972.35"
+    "@aws-sdk/credential-provider-http" "^3.972.37"
+    "@aws-sdk/credential-provider-login" "^3.972.39"
+    "@aws-sdk/credential-provider-process" "^3.972.35"
+    "@aws-sdk/credential-provider-sso" "^3.972.39"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.39"
+    "@aws-sdk/nested-clients" "^3.997.7"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/credential-provider-imds" "^4.3.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.39.tgz#ebe2351eaf09239ea3e5e5ae995095d48f0444ea"
+  integrity sha512-1hU0NtC04QbFIuoBuF4aQ2A97GsSE5/A0ZJpDijwexsBREIQ4KPRYl3v/FfKCPBYsaTeGjkOFx5nLhWHY24LOw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/nested-clients" "^3.997.7"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.40":
+  version "3.972.40"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.40.tgz#8030dd2603e12decd8327864ab699ff3b907818c"
+  integrity sha512-ZgrQaGkpyTlVSCCsffzijVg+KgftTAWYvI5Otc36J/4jNiHb+7MmBiJIR0a5AHLvifC92PiYHt5pijP0dswd1w==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.35"
+    "@aws-sdk/credential-provider-http" "^3.972.37"
+    "@aws-sdk/credential-provider-ini" "^3.972.39"
+    "@aws-sdk/credential-provider-process" "^3.972.35"
+    "@aws-sdk/credential-provider-sso" "^3.972.39"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.39"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/credential-provider-imds" "^4.3.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.35":
+  version "3.972.35"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.35.tgz#7a9e6e351d36b77a3bb7f774e7f25dbb4f8a397d"
+  integrity sha512-hNj1rAwZWT1vfz54BwH8FUWxZuqStrM25Q5LEIwn2erHPMRVAjLlpZqEbCEEqS99eEEOhdeetnS0WeNa3iYeEQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.39.tgz#8fe2ff17646c029966d60784bdbe37bae8d2044d"
+  integrity sha512-mwIPNPldyCZkvHozb6E0X/vuQLN1UCjcA6MwUf1gaO7EwghCmuNZXatq0L3zptKFvPC4Nds7+WFUkifI1XmbSw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/nested-clients" "^3.997.7"
+    "@aws-sdk/token-providers" "3.1046.0"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.39.tgz#70454570d5def22b031911477db5c9aeb49ecfdc"
+  integrity sha512-b9HT8CnpyPVn1hU14Q7ihjwSPlRzToYmRYJxRd5jNHEZ43lrIhoLaTT8JmfQQt5j5M8rTX1iN1X8mvu0SM1dXA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/nested-clients" "^3.997.7"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-bucket-endpoint@^3.972.11":
+  version "3.972.11"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.11.tgz#066137642fcc66db863446c1cbe0f9805cb893fc"
+  integrity sha512-AhVDn+qObNacklqmBABnFa3YfVk08CzksuuecL/x+lo95dZxXuAkqJZLUsAEKQ3EiDd5E9wTUBjh0cSogmKMYA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-expect-continue@^3.972.11":
+  version "3.972.11"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.11.tgz#0032f71381e720a6540263225dfd6b81ef3d9278"
+  integrity sha512-xpobcctR1AHSrvkiArgTyLffn78Lt9unPMpa/yic9RKn+bOf/5M55UIM6RaPL5xKzI06/GSsTDywTWvzEAbyyw==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-flexible-checksums@^3.974.17":
+  version "3.974.17"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.17.tgz#de2633bb3720202ae699fef6e0b17051ae6c47cf"
+  integrity sha512-Js24a6sdH9SU5DI5++nlQJayCuOweiiTjnCcAsY75/JtaXF+xysDQ6nRBYx6pUPNY22viRYmdDTFZDaA9AF46g==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@aws-crypto/crc32c" "5.2.0"
+    "@aws-crypto/util" "5.2.0"
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/crc64-nvme" "^3.972.8"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-host-header@^3.972.11":
+  version "3.972.11"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.11.tgz#222152cc6631e79298b122275c5f9b37cf706478"
+  integrity sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-location-constraint@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz#5265ea472f735c50b016bb5d1b46c7a616653733"
+  integrity sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-logger@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz#d92b3374dcaddd523930bdff441207946343c270"
+  integrity sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@^3.972.12":
+  version "3.972.12"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.12.tgz#b91cf1b3cf9e06900eb5069624fc99c333cfe1b5"
+  integrity sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@aws/lambda-invoke-store" "^0.2.2"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-sdk-s3@^3.972.38":
+  version "3.972.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.38.tgz#46fd665d8c80ec28736fe28813dab63e2ea0e1f0"
+  integrity sha512-Yuv3urkJtd1/b3kIURzHwihc1SV6n1t+uiXffOD2OpylZ7+4/QnO2W73yhLZzK1Z762BaqwQ3IVRqAHWzNbQ4A==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.26"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/signature-v4" "^5.4.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-ssec@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz#46b5c030c0116f51110e18042ad3cf863ab5c81c"
+  integrity sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-user-agent@^3.972.39":
+  version "3.972.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.39.tgz#ba788d4715951f24660bf8e1dd5301b8cfe45915"
+  integrity sha512-MlNSvNsSVlMKKWaCzA0GP1nS4Cuq3WCXUN1vmMvd+Ctztib5kmRcpmTtKx9kikN8szAc+gcdp7uqJJervV2nQg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/util-endpoints" "^3.996.9"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.997.7":
+  version "3.997.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.7.tgz#2f5835f5d3cb2356cf7e8dc9e99f44b0d0efdfde"
+  integrity sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/middleware-host-header" "^3.972.11"
+    "@aws-sdk/middleware-logger" "^3.972.10"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.12"
+    "@aws-sdk/middleware-user-agent" "^3.972.39"
+    "@aws-sdk/region-config-resolver" "^3.972.14"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.26"
+    "@aws-sdk/types" "^3.973.8"
+    "@aws-sdk/util-endpoints" "^3.996.9"
+    "@aws-sdk/util-user-agent-browser" "^3.972.11"
+    "@aws-sdk/util-user-agent-node" "^3.973.25"
+    "@smithy/core" "^3.24.1"
+    "@smithy/fetch-http-handler" "^5.4.1"
+    "@smithy/node-http-handler" "^4.7.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@^3.972.14":
+  version "3.972.14"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.14.tgz#3b757186423c0ed990172a0628307528704baa55"
+  integrity sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@^3.996.26":
+  version "3.996.26"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz#a207d2739fcc64dce16ebb744e0f0b970b32d18c"
+  integrity sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/signature-v4" "^5.4.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1046.0":
+  version "3.1046.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1046.0.tgz#66935393af8883b4146b90d4d612e12ea4f73eb4"
+  integrity sha512-9je8nZt+ntB8IjhpGNayU/AkBgvq/f4aFO2bH1LSNC5JX6K8zY4LUnr/ymqunePrwq+B5OVBpL7ILjYzMFSZAw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.9"
+    "@aws-sdk/nested-clients" "^3.997.7"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.973.8":
+  version "3.973.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.8.tgz#7352cb74a5f8bae1218eee63e714cf94302911c5"
+  integrity sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-endpoints@^3.996.9":
+  version "3.996.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz#3434e8e76011ba05a124947c277ef9eca8a67c65"
+  integrity sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.965.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz#e30e6ff2aff6436209ed42c765dec2d2a48df7c0"
+  integrity sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-browser@^3.972.11":
+  version "3.972.11"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.11.tgz#9215b5931643711d06080e9568be9180992fe916"
+  integrity sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/types" "^4.14.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@^3.973.25":
+  version "3.973.25"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.25.tgz#2c87625063637f53f951457f7d1de177dd95f25a"
+  integrity sha512-066hKH/0nvV7x4ofV/iK9kz8r/qNfcR6rzuEOFqI2vQL/fcTTsDAbTw0jmXkyMzANK8ltQdALj19ns3zuOJiUw==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "^3.972.39"
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/core" "^3.24.1"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.23":
+  version "3.972.23"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.23.tgz#0edf0e1c1b4812880b3349cd3a845b7a55817ae6"
+  integrity sha512-A0YmgYFv+hTI9c17Ntvd2hSehm9bmJfkb+ggADBwVKA8H/3+Jx94SzR2qOB9bAA9WFeDqnfz9PKKQ+D+YAKomA==
+  dependencies:
+    "@nodable/entities" "2.1.0"
+    "@smithy/types" "^4.14.1"
+    fast-xml-parser "5.7.2"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.2.2":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz#802f6a50f6b6589063ef63ba8acdee86fcb9f395"
+  integrity sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
@@ -869,11 +1324,6 @@
   resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.0.tgz#54479e0f406cbad024d6fe1c3190ecca4468df3b"
   integrity sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==
 
-"@fastify/busboy@^2.0.0":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
-  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
-
 "@hono/node-server@^1.19.7":
   version "1.19.7"
   resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.7.tgz#ecb2d3a7af40d1d378e53ce1fc1219f199fbcd6f"
@@ -1484,6 +1934,11 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
+"@nodable/entities@2.1.0", "@nodable/entities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.1.0.tgz#f543e5c6446720d4cf9e498a83019dd159973bc2"
+  integrity sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1700,6 +2155,81 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@smithy/core@^3.24.1", "@smithy/core@^3.24.2":
+  version "3.24.2"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.24.2.tgz#38ae63b029ac5afa156ebd0bfd203bdc3966dd9f"
+  integrity sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.3.1":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.2.tgz#8c84d764844f2065962d26a8df930a024d25f0be"
+  integrity sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA==
+  dependencies:
+    "@smithy/core" "^3.24.2"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.4.1":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.2.tgz#42a2a02227ad227b2970acb7eef7bceb64994b41"
+  integrity sha512-3wF40g8OOCA5BnwQUvwtzZqYBbWWftDjpAlWIUo6Yld3ZzJaMAKqg7MWQBPjE8oLaqvZQUE7tVGlZPsae6A4bQ==
+  dependencies:
+    "@smithy/core" "^3.24.2"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz#f84f0d9f9a36601a9ca9381688bd1b726fd39111"
+  integrity sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.7.1":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.7.2.tgz#94be0d5b2d4cd1398456a889f3ae8af429c33e92"
+  integrity sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA==
+  dependencies:
+    "@smithy/core" "^3.24.2"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.4.1":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.4.2.tgz#54830ba679ec1b5adf06808d37117d9875193f07"
+  integrity sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==
+  dependencies:
+    "@smithy/core" "^3.24.2"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.1.tgz#aba92b4cdb406f2a2b062e82f1e3728d809a7c23"
+  integrity sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz#6fc88585165ec73f8681d426d96de5d402021e4b"
+  integrity sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz#dd96d7640363259924a214313c3cf16e7dd329c5"
+  integrity sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.2.0"
+    tslib "^2.6.2"
 
 "@swagger-api/apidom-ast@^1.0.0-rc.3":
   version "1.0.0-rc.3"
@@ -2715,17 +3245,6 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
-"@vercel/blob@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@vercel/blob/-/blob-2.0.0.tgz#de4536548fc8303cde932269aa09325b8f4e00f6"
-  integrity sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==
-  dependencies:
-    async-retry "^1.3.3"
-    is-buffer "^2.0.5"
-    is-node-process "^1.2.0"
-    throttleit "^2.1.0"
-    undici "^5.28.4"
-
 "@vue/compiler-core@3.5.22":
   version "3.5.22"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.22.tgz#bb8294a0dd31df540563cc6ffa0456f1f7687b97"
@@ -2979,13 +3498,6 @@ async-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
-async-retry@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
-  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
-  dependencies:
-    retry "0.13.1"
-
 async@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
@@ -3173,6 +3685,11 @@ body-parser@^2.2.0:
     qs "^6.14.0"
     raw-body "^3.0.0"
     type-is "^2.0.0"
+
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^1.1.7:
   version "1.1.12"
@@ -4492,6 +5009,24 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
+fast-xml-builder@^1.1.5:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
+  integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
+  dependencies:
+    path-expression-matcher "^1.5.0"
+    xml-naming "^0.1.0"
+
+fast-xml-parser@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz#fecd0b054c6c132fc03dab994a413da781e0eb9f"
+  integrity sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==
+  dependencies:
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.5"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
+
 fastq@^1.6.0:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.1.tgz#d50eaba803c8846a883c16492821ebcd2cda55f5"
@@ -5160,11 +5695,6 @@ is-boolean-object@^1.2.1:
   dependencies:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
-
-is-buffer@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
-  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-bun-module@^2.0.0:
   version "2.0.0"
@@ -7213,6 +7743,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -7782,11 +8317,6 @@ ret@^0.2.0:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.2.2.tgz#b6861782a1f4762dce43402a71eb7a283f44573c"
   integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
 
-retry@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
-
 rettime@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/rettime/-/rettime-0.7.0.tgz#c040f1a65e396eaa4b8346dd96ed937edc79d96f"
@@ -8331,6 +8861,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strnum@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.3.0.tgz#81bfbfef53db8c3217ea62a98c026886ec4a2761"
+  integrity sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==
+
 style-to-js@^1.0.0:
   version "1.1.21"
   resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.21.tgz#2908941187f857e79e28e9cd78008b9a0b3e0e8d"
@@ -8515,11 +9050,6 @@ text-decoder@^1.1.0:
   dependencies:
     b4a "^1.6.4"
 
-throttleit@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-2.1.0.tgz#a7e4aa0bf4845a5bd10daa39ea0c783f631a07b4"
-  integrity sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==
-
 tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
@@ -8678,7 +9208,7 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -8822,13 +9352,6 @@ undici-types@~7.14.0:
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.14.0.tgz#4c037b32ca4d7d62fae042174604341588bc0840"
   integrity sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==
-
-undici@^5.28.4:
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
-  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
 
 undici@^7.24.5:
   version "7.25.0"
@@ -9173,6 +9696,11 @@ xml-name-validator@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
   integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xml-naming@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
+  integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
 
 xml@=1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary

- Replace `@vercel/blob` with `@aws-sdk/client-s3`. New `R2StorageService` writes/reads via R2's S3-compatible API and serves objects through a public custom domain (`R2_PUBLIC_BASE_URL`). The `Storage` interface, `LocalStorageService`, and `createStorageService()` factory are unchanged.
- Rename `MissingBlobTokenError` → `MissingStorageCredentialsError` and consolidate it into `src/lib/storage-errors.ts`. Previously the storage layer and `lib/helm.ts` each defined their own class with the same name, so the `instanceof` check in the cron route never matched the storage-thrown error — this PR fixes that latent bug while doing the rename.
- `.env.example`, `CLAUDE.md`, `README.md`, `UT-spec-description.md`, and the cron test are updated for the new env vars and error name. `code_check.yml` drops the now-unused `BLOB_READ_WRITE_TOKEN` from the build env (CI already runs in `ENABLE_LOCAL_MODE=true`).

## Manual steps before / after merge

**Before merge** (Cloudflare side, one-time):
1. Create R2 bucket `dify-helm-watchdog`.
2. Attach custom domain `dify-watchdog-blobs.langgenius.app`.
3. Generate an S3 API token (Object Read & Write) scoped to the bucket.
4. Pre-copy existing data: `rclone sync vercel-blob:helm-watchdog r2:dify-helm-watchdog/helm-watchdog --progress --checksum`. Keys preserve the `helm-watchdog/...` prefix so the URLs already in `cache.json` line up with the new public domain.
5. Add the five `R2_*` env vars to the Vercel project (Production + Preview):
   - `R2_ACCOUNT_ID`
   - `R2_ACCESS_KEY_ID`
   - `R2_SECRET_ACCESS_KEY`
   - `R2_BUCKET=dify-helm-watchdog`
   - `R2_PUBLIC_BASE_URL=https://dify-watchdog-blobs.langgenius.app`

**After deploy + ~24h soak**:
- Remove `BLOB_READ_WRITE_TOKEN` from Vercel and from GitHub Actions secrets.
- Decommission the old Vercel Blob store.

## Out of scope

- Removing the duplicate legacy route `src/app/api/cron/route.ts` — tracked as #16. This PR only renames the error import in that file.
- Switching MCP transports or analytics-worker code.
- Presigned-URL flow (R2 supports it but we don't need it; bucket is public via custom domain, matching today's behavior).

## Test plan

- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint` — no new warnings
- [x] `yarn test` — 109/109 pass (cron test updated for new error name + message)
- [x] `ENABLE_LOCAL_MODE=true yarn build` — builds end-to-end
- [ ] After R2 provisioning: locally `curl -X POST http://localhost:3000/api/v1/cron -H "Authorization: Bearer $CRON_API_KEY"` with the five R2 vars set → confirm objects appear in R2 dashboard and `/api/v1/versions/latest` returns URLs at `dify-watchdog-blobs.langgenius.app`.
- [ ] After Vercel deploy: trigger one production cron run and check the homepage + `/api/v1/versions/latest` resolve correctly against R2.