### PR TITLE
cache /dashboard analytics query for 5 minutes

### DIFF
--- a/dify-helm-watchdog/src/app/dashboard/page.tsx
+++ b/dify-helm-watchdog/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { unstable_cache } from "next/cache";
 
 import {
   queryAnalytics,
@@ -8,6 +9,12 @@ import {
 } from "@/lib/analytics/track";
 
 import { WindowToggle } from "./window-toggle";
+
+const getCachedAnalytics = unstable_cache(
+  (window: "7d" | "30d" | "90d") => queryAnalytics(window),
+  ["dashboard-analytics"],
+  { revalidate: 300, tags: ["analytics"] },
+);
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -195,7 +202,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
   let errorMessage: string | null = null;
 
   try {
-    data = await queryAnalytics(windowParam);
+    data = await getCachedAnalytics(windowParam);
   } catch (error) {
     errorMessage =
       error instanceof Error ? error.message : "analytics unavailable";


### PR DESCRIPTION
## Summary
- Wrap `queryAnalytics` in `unstable_cache` (keyed by window, `revalidate: 300`) inside `dashboard/page.tsx` so repeat visits hit Next.js's data cache instead of POSTing the Cloudflare Worker every time.
- Page stays `force-dynamic` — only the worker query is memoized.

## Why not `next: { revalidate: 300 }` on the fetch?
The worker request is a signed POST with `X-Timestamp` / `X-Signature` headers that change every call. Next.js 15's fetch cache key includes request headers (verified in `next/dist/server/lib/incremental-cache/index.js`), so a per-fetch revalidate would never hit. `unstable_cache` keys by the function arg (`window`) instead, sidestepping the header churn.

## Test plan
- [x] `yarn lint` clean (only pre-existing warnings)
- [x] `npx tsc --noEmit` clean
- [x] `yarn test` — 109/109 pass
- [ ] After deploy: hit `/dashboard?window=7d` twice within 5 min, confirm only the first request reaches the worker (`wrangler tail` or worker logs).