### PR TITLE
Add time-series traffic chart to /dashboard

### DIFF
--- a/cloudflare/analytics-worker/README.md
+++ b/cloudflare/analytics-worker/README.md
@@ -23,6 +23,15 @@ No raw IP, user-agent, referrer, URL params, or body is ever stored. Country
 is set by Vercel's edge based on the caller IP and cannot be forged by the
 client (it never appears in the JSON-RPC / HTTP body).
 
+## `/query` response
+
+`POST /query` (signed) returns window-aggregated stats: per-kind totals
+(`mcp` / `api` / `page`), `byCountry` (top countries), and `timeseries` —
+one `{ date, country, hits }` row per day per country
+(`GROUP BY toStartOfInterval(timestamp, INTERVAL '1' DAY), blob3`). The
+dashboard rolls the daily rows up to weekly buckets client-side for the 90d
+window; the SQL always returns daily granularity.
+
 ## What exists in Cloudflare (as of first deploy)
 
 | Resource | Identifier | Where to find it |

--- a/cloudflare/analytics-worker/src/index.ts
+++ b/cloudflare/analytics-worker/src/index.ts
@@ -325,7 +325,13 @@ const handleQuery = async (
       queryKind(env, "api", days),
       queryKind(env, "page", days),
       queryCountries(env, days),
-      queryTimeseries(env, days),
+      // Non-fatal: a timeseries failure (e.g. an AE SQL rejection) must not
+      // take down the rest of /query — the dashboard panels keep working and
+      // only the time-series chart degrades to its empty state.
+      queryTimeseries(env, days).catch((error): TimeseriesRow[] => {
+        console.error("queryTimeseries failed", error);
+        return [];
+      }),
     ]);
     const result: QueryResult = {
       window: payload.window,

--- a/cloudflare/analytics-worker/src/index.ts
+++ b/cloudflare/analytics-worker/src/index.ts
@@ -294,8 +294,8 @@ const queryTimeseries = async (
     FROM ${DATASET}
     WHERE timestamp > NOW() - INTERVAL '${days}' DAY
     GROUP BY country, day
-    ORDER BY day ASC
-    LIMIT 5000
+    ORDER BY day DESC
+    LIMIT 10000
     FORMAT JSON
   `;
   const rows = await runSql(env, sql);

--- a/cloudflare/analytics-worker/src/index.ts
+++ b/cloudflare/analytics-worker/src/index.ts
@@ -32,6 +32,12 @@ interface CountryStats {
   uv: number;
 }
 
+interface TimeseriesRow {
+  date: string;
+  country: string;
+  hits: number;
+}
+
 interface QueryResult {
   window: Window;
   generatedAt: string;
@@ -39,6 +45,7 @@ interface QueryResult {
   api: KindStats;
   page: KindStats;
   byCountry: CountryStats[];
+  timeseries: TimeseriesRow[];
 }
 
 const REPLAY_WINDOW_MS = 5 * 60 * 1000;
@@ -157,6 +164,7 @@ interface AnalyticsRow {
   hits?: number;
   uv?: number;
   country?: string;
+  day?: string;
 }
 
 interface AnalyticsResponse {
@@ -271,6 +279,37 @@ const queryCountries = async (
     .slice(0, 20);
 };
 
+const queryTimeseries = async (
+  env: Env,
+  days: number,
+): Promise<TimeseriesRow[]> => {
+  // One row per (day, country). Always daily — the dashboard rolls daily
+  // buckets up to weekly client-side, so the SQL stays single-shaped.
+  // toStartOfInterval is the day-truncation function accepted by AE SQL.
+  const sql = `
+    SELECT
+      blob3 AS country,
+      toStartOfInterval(timestamp, INTERVAL '1' DAY) AS day,
+      sum(_sample_interval) AS hits
+    FROM ${DATASET}
+    WHERE timestamp > NOW() - INTERVAL '${days}' DAY
+    GROUP BY country, day
+    ORDER BY day ASC
+    LIMIT 5000
+    FORMAT JSON
+  `;
+  const rows = await runSql(env, sql);
+  return rows.map((row) => {
+    const raw = String(row.country ?? "");
+    const country = /^[A-Z]{2}$/.test(raw) ? raw : "XX";
+    return {
+      date: String(row.day ?? "").slice(0, 10),
+      country,
+      hits: Number(row.hits ?? 0),
+    };
+  });
+};
+
 const handleQuery = async (
   payload: unknown,
   env: Env,
@@ -281,11 +320,12 @@ const handleQuery = async (
   const days = WINDOW_DAYS[payload.window];
 
   try {
-    const [mcp, api, page, byCountry] = await Promise.all([
+    const [mcp, api, page, byCountry, timeseries] = await Promise.all([
       queryKind(env, "mcp", days),
       queryKind(env, "api", days),
       queryKind(env, "page", days),
       queryCountries(env, days),
+      queryTimeseries(env, days),
     ]);
     const result: QueryResult = {
       window: payload.window,
@@ -294,6 +334,7 @@ const handleQuery = async (
       api,
       page,
       byCountry,
+      timeseries,
     };
     return new Response(JSON.stringify(result), {
       status: 200,

--- a/dify-helm-watchdog/package.json
+++ b/dify-helm-watchdog/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "echarts": "^6.0.0",
     "framer-motion": "^12.23.24",
     "isomorphic-dompurify": "^3.8.0",
     "lucide-react": "^0.548.0",

--- a/dify-helm-watchdog/src/app/dashboard/layout.tsx
+++ b/dify-helm-watchdog/src/app/dashboard/layout.tsx
@@ -1,0 +1,10 @@
+// The root layout locks `body { overflow: hidden }` and wraps every page in a
+// fixed `h-screen` div for the app-like home page. The dashboard is a long
+// document, so it needs its own scroll container to avoid being clipped.
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className="h-full overflow-y-auto">{children}</div>;
+}

--- a/dify-helm-watchdog/src/app/dashboard/page.tsx
+++ b/dify-helm-watchdog/src/app/dashboard/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { unstable_cache } from "next/cache";
 
+import { TrafficChartLoader } from "@/components/analytics/traffic-chart-loader";
+import { COUNTRY_NAMES, countryFlag } from "@/lib/analytics/countries";
+import { buildTrafficSeries } from "@/lib/analytics/timeseries";
 import {
   queryAnalytics,
   type AnalyticsQueryResponse,
@@ -110,36 +113,6 @@ function Panel({ title, subtitle, stats, showBreakdown }: PanelProps) {
 
 const EMPTY_STATS: KindStats = { total: 0, uv: 0, byName: [] };
 
-const COUNTRY_NAMES: Record<string, string> = {
-  US: "United States",
-  CN: "China",
-  JP: "Japan",
-  KR: "South Korea",
-  DE: "Germany",
-  GB: "United Kingdom",
-  FR: "France",
-  IN: "India",
-  SG: "Singapore",
-  HK: "Hong Kong",
-  TW: "Taiwan",
-  CA: "Canada",
-  AU: "Australia",
-  NL: "Netherlands",
-  BR: "Brazil",
-  RU: "Russia",
-  XX: "Unknown",
-};
-
-const countryFlag = (code: string): string => {
-  if (code === "XX" || !/^[A-Z]{2}$/.test(code)) return "🌐";
-  const A = 0x41;
-  const REGIONAL_INDICATOR_A = 0x1f1e6;
-  return (
-    String.fromCodePoint(code.charCodeAt(0) - A + REGIONAL_INDICATOR_A) +
-    String.fromCodePoint(code.charCodeAt(1) - A + REGIONAL_INDICATOR_A)
-  );
-};
-
 function CountryPanel({ rows }: { rows: CountryStats[] }) {
   const top = rows.slice(0, 10);
   const max = top.reduce((m, r) => (r.hits > m ? r.hits : m), 0) || 1;
@@ -212,6 +185,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
   const api = data?.api ?? EMPTY_STATS;
   const page = data?.page ?? EMPTY_STATS;
   const byCountry = data?.byCountry ?? [];
+  const traffic = buildTrafficSeries(data?.timeseries ?? [], windowParam);
   const generatedAt = data?.generatedAt
     ? new Date(data.generatedAt).toLocaleString("en-US", {
         timeZone: "UTC",
@@ -242,6 +216,18 @@ export default async function DashboardPage({ searchParams }: PageProps) {
           analytics unavailable: {errorMessage}
         </div>
       ) : null}
+
+      <section className="flex flex-col gap-4 rounded-lg border border-zinc-800/80 bg-zinc-950/50 p-5">
+        <header>
+          <p className="text-xs uppercase tracking-widest text-zinc-500">
+            traffic over time
+          </p>
+          <h2 className="mt-1 font-mono text-sm text-zinc-200">
+            Requests by country
+          </h2>
+        </header>
+        <TrafficChartLoader buckets={traffic.buckets} series={traffic.series} />
+      </section>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
         <Panel

--- a/dify-helm-watchdog/src/app/dashboard/page.tsx
+++ b/dify-helm-watchdog/src/app/dashboard/page.tsx
@@ -193,7 +193,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
     : null;
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-12">
+    <main className="mx-auto flex min-h-full max-w-5xl flex-col gap-8 px-6 py-12">
       <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="font-mono text-xs uppercase tracking-widest text-emerald-400/80">

--- a/dify-helm-watchdog/src/components/analytics/traffic-chart-loader.tsx
+++ b/dify-helm-watchdog/src/components/analytics/traffic-chart-loader.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { TrafficSeries } from "@/lib/analytics/timeseries";
+
+// ECharts is browser-only and heavy — load it lazily, client-side only, so it
+// never enters the SSR bundle or any route other than /dashboard.
+const TrafficChart = dynamic(() => import("./traffic-chart"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[280px] items-center justify-center font-mono text-xs text-zinc-600">
+      loading chart…
+    </div>
+  ),
+});
+
+export function TrafficChartLoader(props: TrafficSeries) {
+  return <TrafficChart {...props} />;
+}

--- a/dify-helm-watchdog/src/components/analytics/traffic-chart.tsx
+++ b/dify-helm-watchdog/src/components/analytics/traffic-chart.tsx
@@ -31,7 +31,6 @@ echarts.use([
 interface TooltipParam {
   seriesName: string;
   value: number;
-  color: string;
   axisValueLabel: string;
 }
 
@@ -54,9 +53,8 @@ const formatTooltip = (raw: unknown): string => {
   }
   const body = rows
     .map((p) => {
-      const dot = `<span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:${p.color};margin-right:6px"></span>`;
       const name = `${countryFlag(p.seriesName)} ${countryLabel(p.seriesName)}`;
-      return `<div style="display:flex;justify-content:space-between;gap:16px"><span>${dot}${name}</span><span style="color:#e4e4e7">${Number(p.value).toLocaleString("en-US")}</span></div>`;
+      return `<div style="display:flex;justify-content:space-between;gap:16px"><span>${name}</span><span style="color:#e4e4e7">${Number(p.value).toLocaleString("en-US")}</span></div>`;
     })
     .join("");
   const totalRow = `<div style="display:flex;justify-content:space-between;gap:16px;margin-top:4px;border-top:1px solid #3f3f46;padding-top:4px;color:#a1a1aa"><span>total</span><span>${total.toLocaleString("en-US")}</span></div>`;
@@ -94,8 +92,10 @@ export default function TrafficChart({ buckets, series }: TrafficSeries) {
       legend: {
         top: 0,
         textStyle: { color: "#a1a1aa", fontFamily: "monospace", fontSize: 11 },
-        itemWidth: 10,
-        itemHeight: 10,
+        // No color swatch — the flag emoji alone identifies each country.
+        itemWidth: 0,
+        itemHeight: 0,
+        itemGap: 14,
         formatter: (name: string) =>
           `${countryFlag(name)} ${countryLabel(name)}`,
       },

--- a/dify-helm-watchdog/src/components/analytics/traffic-chart.tsx
+++ b/dify-helm-watchdog/src/components/analytics/traffic-chart.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import * as echarts from "echarts/core";
+import { BarChart } from "echarts/charts";
+import {
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+} from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+
+import {
+  COUNTRY_COLORS,
+  OTHER_COLOR,
+  OTHER_LABEL,
+  countryFlag,
+  countryLabel,
+} from "@/lib/analytics/countries";
+import type { TrafficSeries } from "@/lib/analytics/timeseries";
+
+echarts.use([
+  BarChart,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+  CanvasRenderer,
+]);
+
+interface TooltipParam {
+  seriesName: string;
+  value: number;
+  color: string;
+  axisValueLabel: string;
+}
+
+const seriesColor = (country: string, index: number): string =>
+  country === OTHER_LABEL
+    ? OTHER_COLOR
+    : COUNTRY_COLORS[index % COUNTRY_COLORS.length];
+
+const formatTooltip = (raw: unknown): string => {
+  const params = (Array.isArray(raw) ? raw : [raw]) as TooltipParam[];
+  if (params.length === 0) return "";
+  const rows = params
+    .filter((p) => Number(p.value) > 0)
+    .sort((a, b) => Number(b.value) - Number(a.value));
+  const total = params.reduce((sum, p) => sum + Number(p.value || 0), 0);
+
+  const header = `<div style="margin-bottom:4px;color:#a1a1aa">${params[0].axisValueLabel}</div>`;
+  if (rows.length === 0) {
+    return `${header}<div style="color:#52525b">no traffic</div>`;
+  }
+  const body = rows
+    .map((p) => {
+      const dot = `<span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:${p.color};margin-right:6px"></span>`;
+      const name = `${countryFlag(p.seriesName)} ${countryLabel(p.seriesName)}`;
+      return `<div style="display:flex;justify-content:space-between;gap:16px"><span>${dot}${name}</span><span style="color:#e4e4e7">${Number(p.value).toLocaleString("en-US")}</span></div>`;
+    })
+    .join("");
+  const totalRow = `<div style="display:flex;justify-content:space-between;gap:16px;margin-top:4px;border-top:1px solid #3f3f46;padding-top:4px;color:#a1a1aa"><span>total</span><span>${total.toLocaleString("en-US")}</span></div>`;
+  return `${header}${body}${totalRow}`;
+};
+
+export default function TrafficChart({ buckets, series }: TrafficSeries) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<ReturnType<typeof echarts.init> | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const chart = echarts.init(containerRef.current, undefined, {
+      renderer: "canvas",
+    });
+    chartRef.current = chart;
+
+    const observer = new ResizeObserver(() => chart.resize());
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+      chart.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    const option = {
+      backgroundColor: "transparent",
+      grid: { top: 36, right: 12, bottom: 28, left: 44 },
+      legend: {
+        top: 0,
+        textStyle: { color: "#a1a1aa", fontFamily: "monospace", fontSize: 11 },
+        itemWidth: 10,
+        itemHeight: 10,
+        formatter: (name: string) =>
+          `${countryFlag(name)} ${countryLabel(name)}`,
+      },
+      tooltip: {
+        trigger: "axis",
+        axisPointer: { type: "shadow" },
+        backgroundColor: "#18181b",
+        borderColor: "#3f3f46",
+        textStyle: { color: "#d4d4d8", fontFamily: "monospace", fontSize: 11 },
+        formatter: formatTooltip,
+      },
+      xAxis: {
+        type: "category",
+        data: buckets,
+        axisLine: { lineStyle: { color: "#3f3f46" } },
+        axisTick: { show: false },
+        axisLabel: {
+          color: "#71717a",
+          fontFamily: "monospace",
+          fontSize: 10,
+          formatter: (value: string) => value.slice(5),
+        },
+      },
+      yAxis: {
+        type: "value",
+        splitLine: { lineStyle: { color: "#27272a" } },
+        axisLabel: { color: "#71717a", fontFamily: "monospace", fontSize: 10 },
+      },
+      series: series.map((s, i) => ({
+        name: s.country,
+        type: "bar",
+        stack: "total",
+        data: s.data,
+        itemStyle: { color: seriesColor(s.country, i) },
+        emphasis: { focus: "series" },
+        barMaxWidth: 36,
+      })),
+    };
+
+    chart.setOption(option as echarts.EChartsCoreOption, true);
+  }, [buckets, series]);
+
+  const hasData = series.some((s) => s.data.some((v) => v > 0));
+
+  return (
+    <div className="relative">
+      <div ref={containerRef} className="h-[280px] w-full" />
+      {!hasData ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <p className="font-mono text-xs text-zinc-600">
+            no traffic in this window
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dify-helm-watchdog/src/lib/analytics/countries.ts
+++ b/dify-helm-watchdog/src/lib/analytics/countries.ts
@@ -1,0 +1,49 @@
+export const COUNTRY_NAMES: Record<string, string> = {
+  US: "United States",
+  CN: "China",
+  JP: "Japan",
+  KR: "South Korea",
+  DE: "Germany",
+  GB: "United Kingdom",
+  FR: "France",
+  IN: "India",
+  SG: "Singapore",
+  HK: "Hong Kong",
+  TW: "Taiwan",
+  CA: "Canada",
+  AU: "Australia",
+  NL: "Netherlands",
+  BR: "Brazil",
+  RU: "Russia",
+  XX: "Unknown",
+};
+
+export const countryFlag = (code: string): string => {
+  if (code === "XX" || !/^[A-Z]{2}$/.test(code)) return "🌐";
+  const A = 0x41;
+  const REGIONAL_INDICATOR_A = 0x1f1e6;
+  return (
+    String.fromCodePoint(code.charCodeAt(0) - A + REGIONAL_INDICATOR_A) +
+    String.fromCodePoint(code.charCodeAt(1) - A + REGIONAL_INDICATOR_A)
+  );
+};
+
+export const countryLabel = (code: string): string =>
+  COUNTRY_NAMES[code] ?? code;
+
+// Distinct hues tuned for the dark (bg-zinc-950) dashboard. Assigned to the
+// stacked-bar series by rank order, so a country always keeps the same color.
+export const COUNTRY_COLORS: readonly string[] = [
+  "#34d399", // emerald-400
+  "#38bdf8", // sky-400
+  "#fbbf24", // amber-400
+  "#a78bfa", // violet-400
+  "#fb7185", // rose-400
+  "#22d3ee", // cyan-400
+  "#a3e635", // lime-400
+  "#fb923c", // orange-400
+];
+
+// "Other" rollup bucket.
+export const OTHER_COLOR = "#52525b"; // zinc-600
+export const OTHER_LABEL = "Other";

--- a/dify-helm-watchdog/src/lib/analytics/timeseries.ts
+++ b/dify-helm-watchdog/src/lib/analytics/timeseries.ts
@@ -1,0 +1,101 @@
+import { OTHER_LABEL } from "./countries";
+import type { TimeseriesRow } from "./track";
+
+export interface TrafficSeries {
+  /** X-axis bucket labels, oldest -> newest (YYYY-MM-DD). */
+  buckets: string[];
+  /** Stacked series: top-8 countries by total hits, then "Other" last. */
+  series: Array<{ country: string; data: number[] }>;
+}
+
+type Window = "7d" | "30d" | "90d";
+
+const TOP_N = 8;
+const DAY_MS = 86_400_000;
+
+// 7d/30d render daily bars; 90d rolls up to ~13 weekly bars to stay readable.
+const BUCKET_SPEC: Record<Window, { bucketDays: number; bucketCount: number }> =
+  {
+    "7d": { bucketDays: 1, bucketCount: 7 },
+    "30d": { bucketDays: 1, bucketCount: 30 },
+    "90d": { bucketDays: 7, bucketCount: 13 },
+  };
+
+const utcMidnight = (d: Date): number =>
+  Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+
+const fmtDate = (ms: number): string => new Date(ms).toISOString().slice(0, 10);
+
+const parseDate = (s: string): number | null => {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+  if (!m) return null;
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+};
+
+/**
+ * Rolls raw per-day-per-country rows into a stacked-bar shape: a fixed grid of
+ * time buckets covering the window, and one series per top-8 country (the rest
+ * folded into "Other"). `now` is injectable for deterministic tests.
+ */
+export function buildTrafficSeries(
+  rows: TimeseriesRow[],
+  window: Window,
+  now: Date = new Date(),
+): TrafficSeries {
+  const { bucketDays, bucketCount } = BUCKET_SPEC[window];
+  const today = utcMidnight(now);
+
+  // Bucket labels, oldest -> newest. Each bucket spans `bucketDays` days and is
+  // labeled by its first (oldest) day.
+  const buckets: string[] = [];
+  for (let i = 0; i < bucketCount; i++) {
+    const fromEnd = bucketCount - 1 - i;
+    const startMs = today - (fromEnd * bucketDays + (bucketDays - 1)) * DAY_MS;
+    buckets.push(fmtDate(startMs));
+  }
+
+  // Assign each row to a bucket index; drop rows outside the window.
+  const placed: Array<{ bucket: number; country: string; hits: number }> = [];
+  for (const row of rows) {
+    const dateMs = parseDate(row.date);
+    if (dateMs === null) continue;
+    const daysAgo = Math.max(0, Math.round((today - dateMs) / DAY_MS));
+    const fromEnd = Math.floor(daysAgo / bucketDays);
+    if (fromEnd >= bucketCount) continue;
+    placed.push({
+      bucket: bucketCount - 1 - fromEnd,
+      country: row.country,
+      hits: row.hits,
+    });
+  }
+
+  // Rank countries by in-window hits; keep top 8, fold the rest into "Other".
+  const totals = new Map<string, number>();
+  for (const p of placed) {
+    totals.set(p.country, (totals.get(p.country) ?? 0) + p.hits);
+  }
+  const ranked = [...totals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([country]) => country);
+  const topCountries = ranked.slice(0, TOP_N);
+  const topSet = new Set(topCountries);
+  const hasOther = ranked.length > TOP_N;
+
+  const seriesKeys = hasOther ? [...topCountries, OTHER_LABEL] : topCountries;
+  const dataByKey = new Map<string, number[]>(
+    seriesKeys.map((k) => [k, new Array<number>(bucketCount).fill(0)]),
+  );
+
+  for (const p of placed) {
+    const key = topSet.has(p.country) ? p.country : OTHER_LABEL;
+    dataByKey.get(key)![p.bucket] += p.hits;
+  }
+
+  return {
+    buckets,
+    series: seriesKeys.map((country) => ({
+      country,
+      data: dataByKey.get(country)!,
+    })),
+  };
+}

--- a/dify-helm-watchdog/src/lib/analytics/track.ts
+++ b/dify-helm-watchdog/src/lib/analytics/track.ts
@@ -98,6 +98,12 @@ export interface CountryStats {
   uv: number;
 }
 
+export interface TimeseriesRow {
+  date: string;
+  country: string;
+  hits: number;
+}
+
 export interface AnalyticsQueryResponse {
   window: "7d" | "30d" | "90d";
   generatedAt: string;
@@ -105,6 +111,8 @@ export interface AnalyticsQueryResponse {
   api: KindStats;
   page: KindStats;
   byCountry: CountryStats[];
+  // Optional: absent until the analytics worker carrying queryTimeseries is deployed.
+  timeseries?: TimeseriesRow[];
 }
 
 export const queryAnalytics = async (

--- a/dify-helm-watchdog/src/test/lib/analytics/timeseries.test.ts
+++ b/dify-helm-watchdog/src/test/lib/analytics/timeseries.test.ts
@@ -1,0 +1,122 @@
+import { buildTrafficSeries } from "@/lib/analytics/timeseries";
+import type { TimeseriesRow } from "@/lib/analytics/track";
+
+const NOW = new Date("2026-05-15T12:00:00Z");
+
+describe("buildTrafficSeries", () => {
+  it("generates 7 daily buckets for the 7d window with empty input", () => {
+    const result = buildTrafficSeries([], "7d", NOW);
+    expect(result.buckets).toEqual([
+      "2026-05-09",
+      "2026-05-10",
+      "2026-05-11",
+      "2026-05-12",
+      "2026-05-13",
+      "2026-05-14",
+      "2026-05-15",
+    ]);
+    expect(result.series).toEqual([]);
+  });
+
+  it("generates 30 daily buckets for the 30d window", () => {
+    const result = buildTrafficSeries([], "30d", NOW);
+    expect(result.buckets).toHaveLength(30);
+    expect(result.buckets[29]).toBe("2026-05-15");
+    expect(result.buckets[0]).toBe("2026-04-16");
+  });
+
+  it("generates 13 weekly buckets for the 90d window", () => {
+    const result = buildTrafficSeries([], "90d", NOW);
+    expect(result.buckets).toHaveLength(13);
+    // newest bucket is the 7-day window ending today, labeled by its start
+    expect(result.buckets[12]).toBe("2026-05-09");
+  });
+
+  it("places daily rows in the correct bucket and sums hits", () => {
+    const rows: TimeseriesRow[] = [
+      { date: "2026-05-15", country: "US", hits: 10 },
+      { date: "2026-05-15", country: "US", hits: 5 },
+      { date: "2026-05-09", country: "US", hits: 3 },
+    ];
+    const result = buildTrafficSeries(rows, "7d", NOW);
+    const us = result.series.find((s) => s.country === "US");
+    expect(us).toBeDefined();
+    expect(us!.data[6]).toBe(15);
+    expect(us!.data[0]).toBe(3);
+    expect(us!.data[3]).toBe(0);
+  });
+
+  it("drops rows older than the window", () => {
+    const rows: TimeseriesRow[] = [
+      { date: "2026-05-08", country: "US", hits: 99 },
+    ];
+    const result = buildTrafficSeries(rows, "7d", NOW);
+    expect(result.series).toEqual([]);
+  });
+
+  it("aggregates rows within the same week for the 90d window", () => {
+    const rows: TimeseriesRow[] = [
+      { date: "2026-05-15", country: "US", hits: 4 },
+      { date: "2026-05-11", country: "US", hits: 6 },
+    ];
+    const result = buildTrafficSeries(rows, "90d", NOW);
+    const us = result.series.find((s) => s.country === "US")!;
+    expect(us.data[12]).toBe(10);
+  });
+
+  it("keeps the top 8 countries and folds the rest into Other", () => {
+    const rows: TimeseriesRow[] = [
+      "US",
+      "CN",
+      "JP",
+      "KR",
+      "DE",
+      "GB",
+      "FR",
+      "IN",
+      "SG",
+      "HK",
+    ].map((country, i) => ({
+      date: "2026-05-15",
+      country,
+      hits: 100 - i, // US highest, HK lowest
+    }));
+    const result = buildTrafficSeries(rows, "7d", NOW);
+    const names = result.series.map((s) => s.country);
+    expect(names).toHaveLength(9);
+    expect(names.slice(0, 8)).toEqual([
+      "US",
+      "CN",
+      "JP",
+      "KR",
+      "DE",
+      "GB",
+      "FR",
+      "IN",
+    ]);
+    expect(names[8]).toBe("Other");
+    const other = result.series[8];
+    // SG (92) + HK (91)
+    expect(other.data[6]).toBe(183);
+  });
+
+  it("does not emit an Other series when there are 8 or fewer countries", () => {
+    const rows: TimeseriesRow[] = ["US", "CN", "JP"].map((country) => ({
+      date: "2026-05-15",
+      country,
+      hits: 10,
+    }));
+    const result = buildTrafficSeries(rows, "7d", NOW);
+    expect(result.series.map((s) => s.country)).toEqual(["US", "CN", "JP"]);
+  });
+
+  it("orders series by total hits descending", () => {
+    const rows: TimeseriesRow[] = [
+      { date: "2026-05-15", country: "CN", hits: 50 },
+      { date: "2026-05-15", country: "US", hits: 80 },
+      { date: "2026-05-14", country: "JP", hits: 65 },
+    ];
+    const result = buildTrafficSeries(rows, "7d", NOW);
+    expect(result.series.map((s) => s.country)).toEqual(["US", "JP", "CN"]);
+  });
+});

--- a/dify-helm-watchdog/yarn.lock
+++ b/dify-helm-watchdog/yarn.lock
@@ -4363,6 +4363,14 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+echarts@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-6.0.0.tgz#2935aa7751c282d1abbbf7d719d397199a15b9e7"
+  integrity sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==
+  dependencies:
+    tslib "2.3.0"
+    zrender "6.0.0"
+
 eciesjs@^0.4.10:
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/eciesjs/-/eciesjs-0.4.16.tgz#cfa5ddb7b662855d580a8bf4826700dc37191c9a"
@@ -9241,6 +9249,11 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
@@ -9848,6 +9861,13 @@ zod@^3.23.8, zod@^3.24.1:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.5.tgz#aeb269a6f9fc259b1212c348c7c5432aaa474d2a"
   integrity sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==
+
+zrender@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-6.0.0.tgz#947077bc69cdea744134984927f132f3727f8079"
+  integrity sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==
+  dependencies:
+    tslib "2.3.0"
 
 zwitch@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Summary
- Adds a stacked bar chart to `/dashboard` showing requests over time, each bar segmented by country with hover tooltips, full-width above the existing panels.
- **analytics-worker**: new `queryTimeseries` (`GROUP BY toStartOfInterval(timestamp, INTERVAL '1' DAY), blob3`) adds a per-day-per-country `timeseries` array to the `/query` response.
- **`buildTrafficSeries` transform** (`lib/analytics/timeseries.ts`): rolls raw daily rows into top-8 countries + "Other", with daily buckets for 7d/30d and weekly (~13 bars) for 90d.
- **Chart**: ECharts client component, lazy-loaded via `next/dynamic` (`ssr:false`) so it never enters the SSR bundle or other routes — `/dashboard` First Load JS stays ~119 kB.
- `COUNTRY_NAMES`/`countryFlag` extracted to `lib/analytics/countries.ts` for reuse between the server page and the client chart.
- `timeseries` is **optional** on `AnalyticsQueryResponse`, so the page renders a clean empty-state chart until the updated worker is deployed.

## Deploy note
The chart only shows real data after the analytics worker is redeployed:
`cd cloudflare/analytics-worker && wrangler deploy`. Until then it shows "no traffic in this window". The `toStartOfInterval` day-truncation should be sanity-checked against AE SQL on first deploy (commit 9c7681f shows AE rejects some expressions; fallbacks: `toStartOfDay` → `toDate`).

## Test plan
- [x] `yarn test` — 118 pass, incl. 9 new `buildTrafficSeries` tests (top-8+Other rollup, daily/weekly bucketing, window clamping)
- [x] `yarn lint` / `yarn build` — clean
- [x] worker `npx tsc --noEmit` — clean
- [ ] After `wrangler deploy`: confirm bars render with colored country segments, hover tooltip breaks down each bucket, and 7d/30d/90d re-bucket correctly (90d → weekly bars)