### PR TITLE
Mark 3.10.0 as non-skippable

### DIFF
--- a/dify-helm-watchdog/src/components/version-explorer.tsx
+++ b/dify-helm-watchdog/src/components/version-explorer.tsx
@@ -271,6 +271,13 @@ interface ImageTagEntry {
 // Version status from official Dify Helm docs sidebar
 type VersionStatus = "non-skippable" | "archived" | "deprecated";
 
+// Manual status overrides, applied on top of the official sidebar. Use this
+// when a version's status isn't (yet) reflected upstream but we want it
+// surfaced in the UI regardless.
+const MANUAL_VERSION_STATUS: ReadonlyMap<string, VersionStatus> = new Map([
+  ["3.10.0", "non-skippable"],
+]);
+
 const parseSidebarMd = (content: string): Map<string, VersionStatus> => {
   const map = new Map<string, VersionStatus>();
   const lines = content.split("\n");
@@ -290,6 +297,11 @@ const parseSidebarMd = (content: string): Map<string, VersionStatus> => {
     } else if (line.includes("🗑️")) {
       map.set(version, "deprecated");
     }
+  }
+
+  // Manual overrides always win over the upstream sidebar.
+  for (const [version, status] of MANUAL_VERSION_STATUS) {
+    map.set(version, status);
   }
 
   return map;
@@ -361,8 +373,11 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
   // Workflow logs modal state
   const [logsModalOpen, setLogsModalOpen] = useState(false);
 
-  // Version status from official docs (fetched async)
-  const [versionStatusMap, setVersionStatusMap] = useState<Map<string, VersionStatus>>(new Map());
+  // Version status from official docs (fetched async); seeded with manual
+  // overrides so they show even before/without the sidebar fetch.
+  const [versionStatusMap, setVersionStatusMap] = useState<Map<string, VersionStatus>>(
+    () => new Map(MANUAL_VERSION_STATUS),
+  );
 
   const selectVersion = useCallback((v: string) => {
     setSelectedVersion(v);


### PR DESCRIPTION
## What

Manually mark version **3.10.0** as `non-skippable` in the version explorer UI.

## Why

Version status is normally derived from the official Dify Helm docs sidebar (`_sidebar.md`) by matching emoji (`⚠️` → non-skippable). 3.10.0 isn't flagged upstream yet, but we want the non-skippable icon/badge shown now.

## How

- Added a `MANUAL_VERSION_STATUS` override map in `version-explorer.tsx` (`3.10.0` → `non-skippable`).
- `parseSidebarMd` applies these overrides on top of the parsed sidebar, so manual entries always win.
- Seeded the initial `versionStatusMap` state with the overrides so the badge shows even if the sidebar fetch fails or hasn't completed.

To flag future versions, just add another entry to `MANUAL_VERSION_STATUS`.

## Verification

- `yarn lint` — clean (only pre-existing unrelated warnings)
- `npx tsc --noEmit` — passes