### PR TITLE
Exclude 3.10.0 from LTS badge

### DIFF
--- a/dify-helm-watchdog/src/components/version-explorer.tsx
+++ b/dify-helm-watchdog/src/components/version-explorer.tsx
@@ -278,6 +278,10 @@ const MANUAL_VERSION_STATUS: ReadonlyMap<string, VersionStatus> = new Map([
   ["3.10.0", "non-skippable"],
 ]);
 
+// Versions explicitly excluded from the LTS badge, even though they'd
+// otherwise match the version-range rule for LTS.
+const MANUAL_NON_LTS: ReadonlySet<string> = new Set(["3.10.0"]);
+
 const parseSidebarMd = (content: string): Map<string, VersionStatus> => {
   const map = new Map<string, VersionStatus>();
   const lines = content.split("\n");
@@ -1026,7 +1030,10 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
                   const isActive = version.version === selectedVersion;
                   const showDiffIcon = !isActive && Boolean(selectedVersion);
                   const showWizardButton = isActive;
-                  const isLts = semver.valid(version.version) && semver.gte(version.version, "3.9.0");
+                  const isLts =
+                    !MANUAL_NON_LTS.has(version.version) &&
+                    semver.valid(version.version) &&
+                    semver.gte(version.version, "3.9.0");
                   return (
                     <motion.li
                       key={version.version}


### PR DESCRIPTION
## What

Stop showing the **LTS** badge for version **3.10.0** in the version explorer UI.

## Why

LTS is derived purely from a version-range rule (`>= 3.9.0`), which currently flags 3.10.0 as LTS. 3.10.0 is not an LTS release, so it shouldn't carry the badge.

## How

Mirrors the manual-override approach from #21:

- Added a `MANUAL_NON_LTS` set in `version-explorer.tsx` (`3.10.0`).
- `isLts` now excludes any version in that set before applying the existing `>= 3.9.0` range check.

To exclude future versions, just add another entry to `MANUAL_NON_LTS`.

## Verification

- `yarn lint` — clean (only pre-existing unrelated warnings)
- `npx tsc --noEmit` — passes