### PR TITLE
feat: expose version upgrade status (skippable) in API and MCP

### DIFF
--- a/dify-helm-watchdog/src/app/api/v1/versions/[version]/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/[version]/route.ts
@@ -1,5 +1,6 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
 import { loadCache } from "@/lib/helm";
+import { isSkippable } from "@/lib/version-status";
 
 export const runtime = "nodejs";
 
@@ -67,6 +68,8 @@ export async function GET(
       createTime: versionEntry.createTime ?? null,
       chartUrl: versionEntry.chartUrl,
       digest: versionEntry.digest,
+      status: versionEntry.status ?? null,
+      skippable: isSkippable(versionEntry.status),
       assets: {
         values: {
           path: versionEntry.values.path,

--- a/dify-helm-watchdog/src/app/api/v1/versions/latest/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/latest/route.ts
@@ -1,5 +1,6 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
 import { loadCache } from "@/lib/helm";
+import { isSkippable } from "@/lib/version-status";
 
 export const runtime = "nodejs";
 
@@ -63,6 +64,8 @@ export async function GET(request: Request) {
       appVersion: latestVersion.appVersion ?? null,
       createTime: latestVersion.createTime ?? null,
       digest: latestVersion.digest,
+      status: latestVersion.status ?? null,
+      skippable: isSkippable(latestVersion.status),
       urls: {
         self: `/api/v1/versions/${latestVersion.version}`,
         images: `/api/v1/versions/${latestVersion.version}/images`,

--- a/dify-helm-watchdog/src/app/api/v1/versions/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/route.ts
@@ -1,7 +1,8 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
 import { loadCache } from "@/lib/helm";
-import type { ImageValidationRecord, StoredVersion } from "@/lib/types";
+import type { ImageValidationRecord, StoredVersion, VersionStatus } from "@/lib/types";
 import { countValidationStatuses } from "@/lib/validation";
+import { isSkippable } from "@/lib/version-status";
 
 export const runtime = "nodejs";
 
@@ -10,6 +11,8 @@ interface VersionSummary {
   appVersion: string | null;
   createTime: string | null;
   digest?: string;
+  status: VersionStatus | null;
+  skippable: boolean;
   imageValidation?: {
     total: number;
     allFound: number;
@@ -114,6 +117,8 @@ export async function GET(request: Request) {
           appVersion: version.appVersion ?? null,
           createTime: version.createTime ?? null,
           digest: version.digest,
+          status: version.status ?? null,
+          skippable: isSkippable(version.status),
         };
 
         if (includeValidation) {

--- a/dify-helm-watchdog/src/lib/helm.ts
+++ b/dify-helm-watchdog/src/lib/helm.ts
@@ -32,6 +32,7 @@ import {
   IMAGE_VARIANT_NAMES,
 } from "../constants/helm";
 import { createStorageService } from "../services/storage";
+import { fetchVersionStatusMap } from "./version-status";
 
 
 const storage = createStorageService();
@@ -1026,6 +1027,12 @@ export const syncHelmData = async (
   log("Fetching Helm repository index...");
   const indexEntries = await fetchHelmIndex();
   log(`Retrieved ${indexEntries.length} chart versions from index.`);
+
+  // Fetch upgrade-path status (non-skippable / archived / deprecated) from the
+  // official docs sidebar. Falls back to manual overrides only if unreachable.
+  log("Fetching version status from docs sidebar...");
+  const statusMap = await fetchVersionStatusMap(log);
+  log(`Resolved status for ${statusMap.size} versions.`);
   
   // In local mode, limit to latest 5 versions for faster development
   const isLocalMode = process.env.ENABLE_LOCAL_MODE === "true";
@@ -1153,7 +1160,11 @@ export const syncHelmData = async (
     }
   }
 
-  const sortedVersions = sortVersions(Array.from(knownVersions.values()));
+  // Apply the latest status to every version (including carried-over ones) so
+  // upstream changes are reflected each sync. Unmarked versions clear status.
+  const sortedVersions = sortVersions(Array.from(knownVersions.values())).map(
+    (version) => ({ ...version, status: statusMap.get(version.version) }),
+  );
   const payload: CachePayload = {
     updateTime: new Date().toISOString(),
     versions: sortedVersions,

--- a/dify-helm-watchdog/src/lib/mcp/tools.ts
+++ b/dify-helm-watchdog/src/lib/mcp/tools.ts
@@ -9,6 +9,7 @@ import {
   fetchReleaseNotesAsMarkdown,
 } from "@/lib/release-notes";
 import type { ImageValidationRecord, StoredVersion } from "@/lib/types";
+import { isSkippable } from "@/lib/version-status";
 import { countValidationStatuses, normalizeValidationPayload } from "@/lib/validation";
 import YAML from "yaml";
 import type {
@@ -183,6 +184,8 @@ const listVersions = async (
         appVersion: version.appVersion ?? null,
         createTime: version.createTime ?? null,
         digest: version.digest,
+        status: version.status ?? null,
+        skippable: isSkippable(version.status),
       };
 
       if (includeValidation && version.imageValidation) {
@@ -229,6 +232,8 @@ const getLatestVersion = async (): Promise<McpToolResult> => {
     appVersion: latest.appVersion ?? null,
     createTime: latest.createTime ?? null,
     digest: latest.digest,
+    status: latest.status ?? null,
+    skippable: isSkippable(latest.status),
     urls: {
       self: `/api/v1/versions/${latest.version}`,
       images: `/api/v1/versions/${latest.version}/images`,
@@ -260,6 +265,8 @@ const getVersionDetails = async (
     createTime: entry.createTime ?? null,
     chartUrl: entry.chartUrl,
     digest: entry.digest,
+    status: entry.status ?? null,
+    skippable: isSkippable(entry.status),
     assets: {
       values: {
         path: entry.values.path,

--- a/dify-helm-watchdog/src/lib/types.ts
+++ b/dify-helm-watchdog/src/lib/types.ts
@@ -13,6 +13,10 @@ export interface StoredAsset {
   inline?: string;
 }
 
+// Upgrade-path status sourced from the official Dify Helm docs sidebar.
+// Absent means a normal, skippable version.
+export type VersionStatus = "non-skippable" | "archived" | "deprecated";
+
 export interface StoredVersion {
   version: string;
   appVersion?: string | null;
@@ -22,6 +26,7 @@ export interface StoredVersion {
   values: StoredAsset;
   images: StoredAsset;
   imageValidation?: StoredAsset;
+  status?: VersionStatus;
 }
 
 export interface CachePayload {

--- a/dify-helm-watchdog/src/lib/version-status.ts
+++ b/dify-helm-watchdog/src/lib/version-status.ts
@@ -1,0 +1,70 @@
+import type { VersionStatus } from "@/lib/types";
+
+const SIDEBAR_URL = "https://langgenius.github.io/dify-helm/_sidebar.md";
+
+// Manual status overrides, applied on top of the official sidebar. Use this
+// when a version's status isn't (yet) reflected upstream but we want it
+// surfaced regardless. Manual entries always win over the parsed sidebar.
+export const MANUAL_VERSION_STATUS: ReadonlyMap<string, VersionStatus> = new Map([
+  ["3.10.0", "non-skippable"],
+]);
+
+// Parse the official Dify Helm docs sidebar markdown into a version -> status
+// map. Status is identified by the emoji each entry carries upstream.
+export const parseSidebarMd = (content: string): Map<string, VersionStatus> => {
+  const map = new Map<string, VersionStatus>();
+
+  for (const line of content.split("\n")) {
+    // Extract version number from markdown link, e.g. "[v3.8.0 ...](...)".
+    const versionMatch = line.match(/\[v([\d.]+(?:-[^\]]+)?)/);
+    if (!versionMatch) continue;
+
+    const version = versionMatch[1];
+
+    if (line.includes("⚠️")) {
+      map.set(version, "non-skippable");
+    } else if (line.includes("📦")) {
+      map.set(version, "archived");
+    } else if (line.includes("🗑️")) {
+      map.set(version, "deprecated");
+    }
+  }
+
+  // Manual overrides always win over the upstream sidebar.
+  for (const [version, status] of MANUAL_VERSION_STATUS) {
+    map.set(version, status);
+  }
+
+  return map;
+};
+
+// Fetch and parse the official sidebar. On any failure, returns a map
+// containing only the manual overrides so known statuses are never lost.
+export const fetchVersionStatusMap = async (
+  log: (message: string) => void = () => {},
+): Promise<Map<string, VersionStatus>> => {
+  try {
+    const response = await fetch(SIDEBAR_URL, {
+      headers: { "User-Agent": "dify-helm-watchdog" },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const content = await response.text();
+    return parseSidebarMd(content);
+  } catch (error) {
+    log(
+      `Failed to fetch version status sidebar: ${
+        error instanceof Error ? error.message : "unknown error"
+      }`,
+    );
+    return new Map(MANUAL_VERSION_STATUS);
+  }
+};
+
+// A version is skippable unless it is explicitly marked non-skippable.
+export const isSkippable = (status?: VersionStatus): boolean =>
+  status !== "non-skippable";

--- a/dify-helm-watchdog/src/test/api/v1/versions.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/versions.test.ts
@@ -73,8 +73,48 @@ describe("GET /api/v1/versions", () => {
           appVersion: "1.0.0",
           createTime: "2024-01-01T00:00:00.000Z",
           digest: "sha256:123",
+          status: null,
+          skippable: true,
         },
       ],
+    });
+  });
+
+  it("should surface upgrade-path status and skippable flag", async () => {
+    mockedLoadCache.mockResolvedValueOnce({
+      updateTime: "2024-03-01T00:00:00.000Z",
+      versions: [
+        {
+          version: "3.8.0",
+          appVersion: null,
+          createTime: null,
+          chartUrl: "https://example.com/chart-3.8.0.tgz",
+          digest: undefined,
+          status: "non-skippable",
+          values: {
+            path: "values/3.8.0.yaml",
+            url: "https://example.com/values-3.8.0.yaml",
+            hash: "values-hash-3",
+          },
+          images: {
+            path: "images/3.8.0.yaml",
+            url: "https://example.com/images-3.8.0.yaml",
+            hash: "images-hash-3",
+          },
+        },
+      ],
+    });
+
+    const request = new Request("http://localhost/api/v1/versions");
+    const response = await GET(request);
+    const payload = (await response.json()) as {
+      versions: Array<{ status: string | null; skippable: boolean }>;
+    };
+
+    expect(payload.versions[0]).toMatchObject({
+      version: "3.8.0",
+      status: "non-skippable",
+      skippable: false,
     });
   });
 

--- a/dify-helm-watchdog/src/test/lib/version-status.test.ts
+++ b/dify-helm-watchdog/src/test/lib/version-status.test.ts
@@ -1,0 +1,95 @@
+import {
+  parseSidebarMd,
+  fetchVersionStatusMap,
+  isSkippable,
+  MANUAL_VERSION_STATUS,
+} from "@/lib/version-status";
+
+const SAMPLE_SIDEBAR = `* [v3.10.0](/pages/3_10_0.md)
+* [v3.9.4](/pages/3_9_4.md)
+* [v3.8.0 [⚠️ Non-skippable]](/pages/3_8_0.md)
+* [v3.7.2 [📦 Archived]](/pages/3_7_2.md)
+* [v2.7.1 [🗑️ Deprecated]](/pages/2_7_1.md)
+* [v2.4.0-fix.1](/pages/2_4_0-fix_1.md)
+* not a version line
+`;
+
+describe("parseSidebarMd", () => {
+  it("maps each emoji to the right status", () => {
+    const map = parseSidebarMd(SAMPLE_SIDEBAR);
+
+    expect(map.get("3.8.0")).toBe("non-skippable");
+    expect(map.get("3.7.2")).toBe("archived");
+    expect(map.get("2.7.1")).toBe("deprecated");
+  });
+
+  it("leaves unmarked versions without a status", () => {
+    const map = parseSidebarMd(SAMPLE_SIDEBAR);
+
+    expect(map.has("3.9.4")).toBe(false);
+    expect(map.has("2.4.0-fix.1")).toBe(false);
+  });
+
+  it("lets manual overrides win over the sidebar", () => {
+    // 3.10.0 is unmarked upstream but manually pinned to non-skippable.
+    const map = parseSidebarMd(SAMPLE_SIDEBAR);
+
+    expect(MANUAL_VERSION_STATUS.get("3.10.0")).toBe("non-skippable");
+    expect(map.get("3.10.0")).toBe("non-skippable");
+  });
+});
+
+describe("isSkippable", () => {
+  it("is false only for non-skippable", () => {
+    expect(isSkippable("non-skippable")).toBe(false);
+    expect(isSkippable("archived")).toBe(true);
+    expect(isSkippable("deprecated")).toBe(true);
+    expect(isSkippable(undefined)).toBe(true);
+  });
+});
+
+describe("fetchVersionStatusMap", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("parses a successful response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => SAMPLE_SIDEBAR,
+    }) as unknown as typeof fetch;
+
+    const map = await fetchVersionStatusMap();
+
+    expect(map.get("3.8.0")).toBe("non-skippable");
+    expect(map.get("3.10.0")).toBe("non-skippable");
+  });
+
+  it("falls back to manual overrides when the fetch fails", async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+    const map = await fetchVersionStatusMap();
+
+    // Only the manual overrides survive; nothing from the (failed) sidebar.
+    expect(map.get("3.10.0")).toBe("non-skippable");
+    expect(map.has("3.8.0")).toBe(false);
+    expect(map.size).toBe(MANUAL_VERSION_STATUS.size);
+  });
+
+  it("falls back to manual overrides on a non-ok response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "",
+    }) as unknown as typeof fetch;
+
+    const map = await fetchVersionStatusMap();
+
+    expect(map.get("3.10.0")).toBe("non-skippable");
+    expect(map.has("3.8.0")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

`non-skippable` / `archived` / `deprecated` 状态此前只在前端派生——靠组件挂载时实时 fetch 官方文档 `_sidebar.md` 并按 emoji 解析。结果是 **REST API 和 MCP 工具的返回里没有任何升级路径信息**，AI 客户端只能从 release-notes 文本里自己猜某个版本能不能跳过。

## 改动

把 sidebar 解析挪进 sync，让每个版本的 `status` 落进 `cache.json`，并在接口和 MCP 透出 `status` 以及派生的 `skippable` 布尔（`skippable = status !== "non-skippable"`）。

- **类型** `StoredVersion` 新增 `status?: VersionStatus`
- **新模块** `src/lib/version-status.ts`：`parseSidebarMd` + 手动覆盖表（3.10.0）+ `fetchVersionStatusMap`（带容错回退）+ `isSkippable`
- **sync** 同步时抓一次 `_sidebar.md`，给所有版本（含沿用的旧版本）写上最新 status
- **MCP** `list_versions` / `get_latest_version` / `get_version_details` 返回新增 `status` + `skippable`
- **REST** `/api/v1/versions`、`/versions/latest`、`/versions/{version}` 同样新增 `status` + `skippable`

sidebar 抓取失败时回退到手动覆盖表，已知状态（如 3.10.0 non-skippable）永不丢失。

**前端刻意保持不变**（继续客户端自抓 sidebar），本 PR 只动数据层 + 接口/MCP。

## 测试

- 新增 `version-status.test.ts`（7 个：解析 / 手动覆盖优先 / fetch 成功 / 失败回退 / 非 200 回退 / isSkippable）
- 新增 1 个 `/api/v1/versions` 路由级测试（non-skippable → `skippable:false`）
- 全量 **16 套 / 126 测试通过**，`tsc` 无 src 报错，lint 无新增问题

## 注意

- 生效时机：status 随 sync 落盘，需重新部署 + 跑一次 cron 才会写进 `cache.json`。
- 前端那份 `parseSidebarMd` 副本暂时保留（因为本 PR 不动前端），后续可让前端改读 `version.status` 再删除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)