### PR TITLE
Block scanner fuzzing at the edge to curb Vercel cost

### DIFF
--- a/dify-helm-watchdog/src/app/api/v1/releases/[version]/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/releases/[version]/route.ts
@@ -1,4 +1,5 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
+import { isValidVersion } from "@/lib/api/guard";
 import { sanitizeEeReleaseHtml } from "@/lib/release-notes";
 
 export const runtime = "nodejs";
@@ -34,7 +35,7 @@ export async function GET(
 ) {
   const { version } = await params;
 
-  if (!/^\d+\.\d+\.\d+/.test(version)) {
+  if (!isValidVersion(version)) {
     return createErrorResponse({
       request,
       status: 400,

--- a/dify-helm-watchdog/src/app/api/v1/versions/[version]/images/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/[version]/images/route.ts
@@ -1,4 +1,5 @@
 import { createErrorResponse, createJsonResponse, createTextResponse } from "@/lib/api/response";
+import { isValidVersion } from "@/lib/api/guard";
 import { loadCache } from "@/lib/helm";
 import type { ImageValidationRecord } from "@/lib/types";
 import { normalizeValidationRecord } from "@/lib/validation";
@@ -67,6 +68,16 @@ export async function GET(
 ) {
   try {
     const { version } = await params;
+
+    if (!isValidVersion(version)) {
+      return createErrorResponse({
+        request,
+        status: 400,
+        message: `Invalid version format: ${version}`,
+        statusText: "INVALID_ARGUMENT",
+      });
+    }
+
     const url = new URL(request.url);
     const format = url.searchParams.get("format") || "json";
     const includeValidation = url.searchParams.get("includeValidation") === "true";

--- a/dify-helm-watchdog/src/app/api/v1/versions/[version]/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/[version]/route.ts
@@ -1,4 +1,5 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
+import { isValidVersion } from "@/lib/api/guard";
 import { loadCache } from "@/lib/helm";
 import { isSkippable } from "@/lib/version-status";
 
@@ -32,6 +33,15 @@ export async function GET(
 ) {
   try {
     const { version } = await params;
+
+    if (!isValidVersion(version)) {
+      return createErrorResponse({
+        request,
+        status: 400,
+        message: `Invalid version format: ${version}`,
+        statusText: "INVALID_ARGUMENT",
+      });
+    }
 
     const cache = await loadCache();
     if (!cache) {

--- a/dify-helm-watchdog/src/app/api/v1/versions/[version]/validation/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/[version]/validation/route.ts
@@ -1,4 +1,5 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
+import { isValidVersion } from "@/lib/api/guard";
 import { loadCache } from "@/lib/helm";
 import { normalizeValidationPayload } from "@/lib/validation";
 
@@ -37,6 +38,16 @@ export async function GET(
 ) {
   try {
     const { version } = await params;
+
+    if (!isValidVersion(version)) {
+      return createErrorResponse({
+        request,
+        status: 400,
+        message: `Invalid version format: ${version}`,
+        statusText: "INVALID_ARGUMENT",
+      });
+    }
+
     const url = new URL(request.url);
     const isMissing = url.searchParams.get("isMissing") === "true";
 

--- a/dify-helm-watchdog/src/app/api/v1/versions/[version]/values/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/[version]/values/route.ts
@@ -1,4 +1,5 @@
 import { createErrorResponse, createTextResponse } from "@/lib/api/response";
+import { isValidVersion } from "@/lib/api/guard";
 import { loadCache } from "@/lib/helm";
 
 export const runtime = "nodejs";
@@ -31,6 +32,15 @@ export async function GET(
 ) {
   try {
     const { version } = await params;
+
+    if (!isValidVersion(version)) {
+      return createErrorResponse({
+        request,
+        status: 400,
+        message: `Invalid version format: ${version}`,
+        statusText: "INVALID_ARGUMENT",
+      });
+    }
 
     const cache = await loadCache();
     if (!cache) {

--- a/dify-helm-watchdog/src/lib/analytics/session.ts
+++ b/dify-helm-watchdog/src/lib/analytics/session.ts
@@ -14,7 +14,7 @@ const getSalt = (): string => {
   return process.env.ANALYTICS_SESSION_SALT?.trim() || FALLBACK_SALT;
 };
 
-const extractIp = (headers: Headers): string => {
+export const extractIp = (headers: Headers): string => {
   const forwarded = headers.get("x-forwarded-for");
   if (forwarded) {
     const first = forwarded.split(",")[0]?.trim();

--- a/dify-helm-watchdog/src/lib/api/guard.ts
+++ b/dify-helm-watchdog/src/lib/api/guard.ts
@@ -1,0 +1,33 @@
+// Structural request guards that let the edge middleware and route handlers
+// reject security-scanner fuzzing (path traversal, SSRF, LFI, CRLF injection)
+// before any expensive work runs. Kept dependency-free so it stays cheap to
+// evaluate on the edge.
+
+// Canonical chart-version shape, anchored at both ends. Accepts the SemVer core
+// plus optional prerelease/build metadata, which real cache entries use
+// (e.g. "2.4.0-fix.1", "3.1.0-beta.1", "1.0.0+build.5"). The charset cannot
+// express a slash, percent, backslash, colon, or control character, so no
+// scanner payload can satisfy it.
+export const VERSION_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+export const isValidVersion = (version: string): boolean =>
+  VERSION_RE.test(version);
+
+// Byte patterns that never appear in a legitimate /api/v1 path — legit paths use
+// only [A-Za-z0-9._/-] (version dots are always single-separated). Tested
+// case-insensitively against the RAW, still-encoded path so percent-encoded
+// evasions (%2e, %252f, %c0%af) remain visible.
+//
+//   \.\.                literal ".." traversal (incl. "..%2f", "..\")
+//   %2e %2f %5c         encoded dot / slash / backslash
+//   \\                  raw backslash (Windows-style traversal)
+//   %25                 encoded "%" — the double-encoding marker (%252f, %252e)
+//   %00 / \x00-\x1f\x7f null byte and raw control bytes incl. CR/LF/TAB
+//   %0d %0a %09         encoded CR / LF / TAB (CRLF / header injection)
+//   %[c-f].. %[89ab]..  high-bit / overlong-UTF-8 bytes (e.g. %c0%af)
+//   [:@] / %3a %40      host:port / userinfo (SSRF targets), raw and encoded
+const SUSPICIOUS_RE =
+  /(\.\.|%2e|%2f|%5c|\\|%25|%00|[\x00-\x1f\x7f]|%0d|%0a|%09|%[c-f][0-9a-f]|%[89ab][0-9a-f]|[:@]|%3a|%40)/i;
+
+export const isSuspiciousApiPath = (rawPath: string): boolean =>
+  SUSPICIOUS_RE.test(rawPath);

--- a/dify-helm-watchdog/src/lib/api/rate-limit.ts
+++ b/dify-helm-watchdog/src/lib/api/rate-limit.ts
@@ -18,7 +18,7 @@ export const RATE_LIMIT_WINDOW_MS = resolveWindowMs();
 export const RATE_LIMIT_MAX_HITS = resolveMaxHits();
 
 // Guard against an unbounded map when a flood arrives from many distinct IPs.
-const MAX_KEYS = 10_000;
+export const RATE_LIMIT_MAX_KEYS = 10_000;
 
 const hits = new Map<string, number[]>();
 
@@ -39,6 +39,10 @@ export const checkRateLimit = (
   const cutoff = now - RATE_LIMIT_WINDOW_MS;
   const recent = (hits.get(key) ?? []).filter((t) => t > cutoff);
 
+  // delete + re-set moves this key to the most-recently-used end of the Map, so
+  // insertion order tracks recency and the overflow eviction below is true LRU.
+  hits.delete(key);
+
   if (recent.length >= RATE_LIMIT_MAX_HITS) {
     hits.set(key, recent);
     const retryAfter = Math.max(
@@ -51,13 +55,12 @@ export const checkRateLimit = (
   recent.push(now);
   hits.set(key, recent);
 
-  // Opportunistically drop fully-expired keys so idle entries don't accumulate.
-  if (hits.size > MAX_KEYS) {
-    for (const [k, times] of hits) {
-      const live = times.filter((t) => t > cutoff);
-      if (live.length === 0) hits.delete(k);
-      else hits.set(k, live);
-    }
+  // Bound memory in O(1): when over capacity, evict the least-recently-used key
+  // (first in insertion order). A full O(N) sweep on every request would block
+  // the event loop under a many-IP flood — the exact abuse this guards against.
+  if (hits.size > RATE_LIMIT_MAX_KEYS) {
+    const oldest = hits.keys().next().value;
+    if (oldest !== undefined) hits.delete(oldest);
   }
 
   return { ok: true, retryAfter: 0 };
@@ -67,3 +70,6 @@ export const checkRateLimit = (
 export const __resetRateLimit = (): void => {
   hits.clear();
 };
+
+// Test-only: current number of tracked keys.
+export const __rateLimitSize = (): number => hits.size;

--- a/dify-helm-watchdog/src/lib/api/rate-limit.ts
+++ b/dify-helm-watchdog/src/lib/api/rate-limit.ts
@@ -1,0 +1,69 @@
+// Best-effort in-memory sliding-window rate limiter for the public read API.
+// State lives in module scope, so on Vercel it is PER-INSTANCE (Fluid Compute
+// reuses instances but does not share memory across them) — it throttles a
+// single aggressive client hitting a warm instance without any external store.
+// The hard, global cap belongs in Vercel Firewall; this is a cheap first line.
+
+const resolveWindowMs = (): number => {
+  const raw = Number(process.env.RATE_LIMIT_WINDOW_S);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) * 1000 : 60_000;
+};
+
+const resolveMaxHits = (): number => {
+  const raw = Number(process.env.RATE_LIMIT_MAX);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 100;
+};
+
+export const RATE_LIMIT_WINDOW_MS = resolveWindowMs();
+export const RATE_LIMIT_MAX_HITS = resolveMaxHits();
+
+// Guard against an unbounded map when a flood arrives from many distinct IPs.
+const MAX_KEYS = 10_000;
+
+const hits = new Map<string, number[]>();
+
+export interface RateLimitResult {
+  ok: boolean;
+  retryAfter: number; // seconds until the window frees up
+}
+
+export const checkRateLimit = (
+  key: string,
+  now: number = Date.now(),
+): RateLimitResult => {
+  // Unknown / unroutable callers collapse onto the same key ("0.0.0.0" is the
+  // session.extractIp fallback). Never let one shared bucket throttle everyone
+  // — skip limiting when we cannot identify the caller.
+  if (!key || key === "0.0.0.0") return { ok: true, retryAfter: 0 };
+
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+  const recent = (hits.get(key) ?? []).filter((t) => t > cutoff);
+
+  if (recent.length >= RATE_LIMIT_MAX_HITS) {
+    hits.set(key, recent);
+    const retryAfter = Math.max(
+      1,
+      Math.ceil((recent[0] + RATE_LIMIT_WINDOW_MS - now) / 1000),
+    );
+    return { ok: false, retryAfter };
+  }
+
+  recent.push(now);
+  hits.set(key, recent);
+
+  // Opportunistically drop fully-expired keys so idle entries don't accumulate.
+  if (hits.size > MAX_KEYS) {
+    for (const [k, times] of hits) {
+      const live = times.filter((t) => t > cutoff);
+      if (live.length === 0) hits.delete(k);
+      else hits.set(k, live);
+    }
+  }
+
+  return { ok: true, retryAfter: 0 };
+};
+
+// Test-only: clear module state between cases.
+export const __resetRateLimit = (): void => {
+  hits.clear();
+};

--- a/dify-helm-watchdog/src/middleware.ts
+++ b/dify-helm-watchdog/src/middleware.ts
@@ -7,10 +7,16 @@ import {
 import {
   computeSessionHashFromHeaders,
   extractCountry,
+  extractIp,
 } from "@/lib/analytics/session";
 import { trackEvent, type TrackEventInput } from "@/lib/analytics/track";
+import { isSuspiciousApiPath } from "@/lib/api/guard";
+import { checkRateLimit } from "@/lib/api/rate-limit";
 
 const EXCLUDED_API_PREFIXES = ["cron", "mcp", "sse", "analytics"];
+
+const isExcludedApiSub = (sub: string): boolean =>
+  EXCLUDED_API_PREFIXES.includes(sub.split("/")[0]);
 
 const buildEvent = async (
   req: NextRequest,
@@ -26,8 +32,7 @@ const buildEvent = async (
   if (path.startsWith("/api/v1/")) {
     const sub = path.slice("/api/v1/".length).replace(/^\/+|\/+$/g, "");
     if (!sub) return null;
-    const head = sub.split("/")[0];
-    if (EXCLUDED_API_PREFIXES.includes(head)) return null;
+    if (isExcludedApiSub(sub)) return null;
     const sessionHash = await computeSessionHashFromHeaders(req.headers);
     return { kind: "api", name: sub.slice(0, 200), sessionHash, country };
   }
@@ -39,6 +44,32 @@ export async function middleware(
   req: NextRequest,
   fetchEvent: NextFetchEvent,
 ): Promise<NextResponse> {
+  // Read the raw, still-encoded path: nextUrl.pathname may decode percent-escapes
+  // and hide scanner payloads (%2e, %252f, ...), while URL.pathname preserves them.
+  const rawPath = new URL(req.url).pathname;
+
+  if (rawPath.startsWith("/api/v1/")) {
+    // Reject traversal / SSRF / LFI / CRLF fuzzing structurally. Returning a
+    // non-next() response short-circuits before the route function (and its R2
+    // reads) runs, and skips the outbound analytics fetch entirely.
+    if (isSuspiciousApiPath(rawPath)) {
+      return new NextResponse(null, { status: 400 });
+    }
+
+    // Best-effort rate limit on the public read API. The excluded prefixes have
+    // their own auth (cron) or are long-lived/instrumented (mcp, sse, analytics).
+    const sub = rawPath.slice("/api/v1/".length).replace(/^\/+|\/+$/g, "");
+    if (sub && !isExcludedApiSub(sub)) {
+      const { ok, retryAfter } = checkRateLimit(extractIp(req.headers));
+      if (!ok) {
+        return new NextResponse(null, {
+          status: 429,
+          headers: { "Retry-After": String(retryAfter) },
+        });
+      }
+    }
+  }
+
   try {
     const event = await buildEvent(req);
     if (event) {

--- a/dify-helm-watchdog/src/middleware.ts
+++ b/dify-helm-watchdog/src/middleware.ts
@@ -44,8 +44,12 @@ export async function middleware(
   req: NextRequest,
   fetchEvent: NextFetchEvent,
 ): Promise<NextResponse> {
-  // Read the raw, still-encoded path: nextUrl.pathname may decode percent-escapes
-  // and hide scanner payloads (%2e, %252f, ...), while URL.pathname preserves them.
+  // WHATWG URL keeps percent-encoded octets (%2e, %2f, %5c, %3a, %252f, ...)
+  // verbatim in pathname — it does NOT decode them — so encoded scanner payloads
+  // stay visible to the guard below. The only normalization is collapsing a
+  // standalone real-slash dot-segment ("/%2e%2e/" -> "/"), which is harmless:
+  // that path just 404s, and smuggling real traversal needs an ENCODED slash,
+  // which is preserved and matched. req.nextUrl.pathname behaves identically.
   const rawPath = new URL(req.url).pathname;
 
   if (rawPath.startsWith("/api/v1/")) {

--- a/dify-helm-watchdog/src/test/api/v1/versions/[version]/images.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/versions/[version]/images.test.ts
@@ -50,6 +50,25 @@ worker:
     jest.resetAllMocks();
   });
 
+  it.each(["../etc/passwd", "169.254.169.254", "2.4", "%2e%2e"])(
+    "returns 400 for malformed version %s without calling loadCache",
+    async (version) => {
+      const request = new Request(
+        `http://localhost/api/v1/versions/${version}/images`,
+      );
+      const params = Promise.resolve({ version });
+      const response = await GET(request, { params });
+
+      expect(response.status).toBe(400);
+      expect(mockedLoadCache).not.toHaveBeenCalled();
+
+      const payload = (await response.json()) as {
+        error: { status: string };
+      };
+      expect(payload.error.status).toBe("INVALID_ARGUMENT");
+    },
+  );
+
   it("should return 404 when cache is not available", async () => {
     mockedLoadCache.mockResolvedValueOnce(null);
 

--- a/dify-helm-watchdog/src/test/api/v1/versions/[version]/route.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/versions/[version]/route.test.ts
@@ -13,6 +13,25 @@ describe("GET /api/v1/versions/{version}", () => {
     jest.resetAllMocks();
   });
 
+  it.each(["../etc/passwd", "169.254.169.254", "2.4", "%2e%2e"])(
+    "returns 400 for malformed version %s without calling loadCache",
+    async (version) => {
+      const request = new Request(
+        `http://localhost/api/v1/versions/${version}`,
+      );
+      const params = Promise.resolve({ version });
+      const response = await GET(request, { params });
+
+      expect(response.status).toBe(400);
+      expect(mockedLoadCache).not.toHaveBeenCalled();
+
+      const payload = (await response.json()) as {
+        error: { status: string };
+      };
+      expect(payload.error.status).toBe("INVALID_ARGUMENT");
+    },
+  );
+
   it("should return 404 when cache is not available", async () => {
     mockedLoadCache.mockResolvedValueOnce(null);
 

--- a/dify-helm-watchdog/src/test/api/v1/versions/[version]/validation.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/versions/[version]/validation.test.ts
@@ -48,6 +48,25 @@ describe("GET /api/v1/versions/{version}/validation", () => {
     jest.resetAllMocks();
   });
 
+  it.each(["../etc/passwd", "169.254.169.254", "2.4", "%2e%2e"])(
+    "returns 400 for malformed version %s without calling loadCache",
+    async (version) => {
+      const request = new Request(
+        `http://localhost/api/v1/versions/${version}/validation`,
+      );
+      const params = Promise.resolve({ version });
+      const response = await GET(request, { params });
+
+      expect(response.status).toBe(400);
+      expect(mockedLoadCache).not.toHaveBeenCalled();
+
+      const payload = (await response.json()) as {
+        error: { status: string };
+      };
+      expect(payload.error.status).toBe("INVALID_ARGUMENT");
+    },
+  );
+
   it("should return 404 when cache is not available", async () => {
     mockedLoadCache.mockResolvedValueOnce(null);
 

--- a/dify-helm-watchdog/src/test/api/v1/versions/[version]/values.test.ts
+++ b/dify-helm-watchdog/src/test/api/v1/versions/[version]/values.test.ts
@@ -26,6 +26,25 @@ web:
     jest.resetAllMocks();
   });
 
+  it.each(["../etc/passwd", "169.254.169.254", "2.4", "%2e%2e"])(
+    "returns 400 for malformed version %s without calling loadCache",
+    async (version) => {
+      const request = new Request(
+        `http://localhost/api/v1/versions/${version}/values`,
+      );
+      const params = Promise.resolve({ version });
+      const response = await GET(request, { params });
+
+      expect(response.status).toBe(400);
+      expect(mockedLoadCache).not.toHaveBeenCalled();
+
+      const payload = (await response.json()) as {
+        error: { status: string };
+      };
+      expect(payload.error.status).toBe("INVALID_ARGUMENT");
+    },
+  );
+
   it("should return 404 when cache is not available", async () => {
     mockedLoadCache.mockResolvedValueOnce(null);
 

--- a/dify-helm-watchdog/src/test/lib/api/guard.test.ts
+++ b/dify-helm-watchdog/src/test/lib/api/guard.test.ts
@@ -1,0 +1,71 @@
+import {
+  isSuspiciousApiPath,
+  isValidVersion,
+} from "@/lib/api/guard";
+
+describe("isSuspiciousApiPath", () => {
+  it.each([
+    // path traversal, raw and encoded (incl. double-encoded)
+    "/api/v1/versions/..%2f..%2fetc%2fpasswd/values",
+    "/api/v1/releases/..%2f..%2f..%2fetc%2fpasswd",
+    "/api/v1/versions/%2e%2e%2f",
+    "/api/v1/versions/..%252f..%252fetc%252fpasswd/values",
+    "/api/v1/releases/3.10.0%2f..%2f..%2f..%2fblog",
+    // overlong UTF-8 and high-bit bytes
+    "/api/v1/releases/v3.10.0%c0%af..%c0%af",
+    // null byte and control / CRLF
+    "/api/v1/versions/%00",
+    "/api/v1/releases/3.1.0%0d%0ahost:%20169.254.169.254",
+    // SSRF host:port / userinfo
+    "/api/v1/releases/localhost:8080",
+    "/api/v1/releases/3.10.0%40169.254.169.254",
+    // backslash traversal
+    "/api/v1/versions/..%5c..%5c",
+    // case-insensitivity
+    "/api/v1/versions/%2E%2E%2F",
+  ])("flags scanner path %s", (path) => {
+    expect(isSuspiciousApiPath(path)).toBe(true);
+  });
+
+  it.each([
+    "/api/v1/versions",
+    "/api/v1/versions/latest",
+    "/api/v1/versions/3.10.0",
+    "/api/v1/versions/2.4.0-fix.1/values",
+    "/api/v1/versions/3.1.0-beta.1/images",
+    "/api/v1/versions/2.5.0/validation",
+    "/api/v1/releases/3.10.0",
+    "/api/v1/cache",
+    "/api/v1/mcp",
+    "/api/v1/sse",
+  ])("passes legit path %s", (path) => {
+    expect(isSuspiciousApiPath(path)).toBe(false);
+  });
+});
+
+describe("isValidVersion", () => {
+  it.each([
+    "2.5.0",
+    "3.10.0",
+    "2.4.0-fix.1",
+    "3.1.0-beta.1",
+    "1.0.0+build.5",
+  ])("accepts %s", (v) => {
+    expect(isValidVersion(v)).toBe(true);
+  });
+
+  it.each([
+    "latest",
+    "2.4",
+    "169.254.169.254",
+    "../etc/passwd",
+    "2.5.0/../",
+    "2.5.0%2f",
+    " 2.5.0",
+    "2.5.0-",
+    "v3.10.0",
+    "",
+  ])("rejects %s", (v) => {
+    expect(isValidVersion(v)).toBe(false);
+  });
+});

--- a/dify-helm-watchdog/src/test/lib/api/rate-limit.test.ts
+++ b/dify-helm-watchdog/src/test/lib/api/rate-limit.test.ts
@@ -1,7 +1,9 @@
 import {
   checkRateLimit,
   RATE_LIMIT_MAX_HITS,
+  RATE_LIMIT_MAX_KEYS,
   RATE_LIMIT_WINDOW_MS,
+  __rateLimitSize,
   __resetRateLimit,
 } from "@/lib/api/rate-limit";
 
@@ -46,5 +48,29 @@ describe("checkRateLimit", () => {
       expect(checkRateLimit("0.0.0.0", now).ok).toBe(true);
       expect(checkRateLimit("", now).ok).toBe(true);
     }
+  });
+
+  it("bounds memory to MAX_KEYS under a many-IP flood", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < RATE_LIMIT_MAX_KEYS + 500; i++) {
+      checkRateLimit(`10.${(i >> 16) & 255}.${(i >> 8) & 255}.${i & 255}`, now);
+    }
+    expect(__rateLimitSize()).toBeLessThanOrEqual(RATE_LIMIT_MAX_KEYS);
+  });
+
+  it("keeps a recently-active key alive under eviction pressure (LRU, not FIFO)", () => {
+    const now = 1_000_000;
+    // Drive "attacker" to its limit, inserted first so naive FIFO would evict it.
+    for (let i = 0; i < RATE_LIMIT_MAX_HITS; i++) checkRateLimit("attacker", now);
+    expect(checkRateLimit("attacker", now).ok).toBe(false);
+
+    // Flood with distinct keys, touching "attacker" each round to keep it recent.
+    for (let i = 0; i < RATE_LIMIT_MAX_KEYS + 100; i++) {
+      checkRateLimit(`flood-${i}`, now);
+      checkRateLimit("attacker", now);
+    }
+
+    // It survived eviction, so its bucket is intact and still over the limit.
+    expect(checkRateLimit("attacker", now).ok).toBe(false);
   });
 });

--- a/dify-helm-watchdog/src/test/lib/api/rate-limit.test.ts
+++ b/dify-helm-watchdog/src/test/lib/api/rate-limit.test.ts
@@ -1,0 +1,50 @@
+import {
+  checkRateLimit,
+  RATE_LIMIT_MAX_HITS,
+  RATE_LIMIT_WINDOW_MS,
+  __resetRateLimit,
+} from "@/lib/api/rate-limit";
+
+describe("checkRateLimit", () => {
+  afterEach(() => {
+    __resetRateLimit();
+  });
+
+  it("allows requests up to the limit, then denies", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < RATE_LIMIT_MAX_HITS; i++) {
+      expect(checkRateLimit("1.2.3.4", now).ok).toBe(true);
+    }
+    const denied = checkRateLimit("1.2.3.4", now);
+    expect(denied.ok).toBe(false);
+    expect(denied.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("keeps separate buckets per key", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < RATE_LIMIT_MAX_HITS; i++) {
+      checkRateLimit("1.1.1.1", now);
+    }
+    expect(checkRateLimit("1.1.1.1", now).ok).toBe(false);
+    // A different IP is unaffected.
+    expect(checkRateLimit("2.2.2.2", now).ok).toBe(true);
+  });
+
+  it("frees the window once old hits age out", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < RATE_LIMIT_MAX_HITS; i++) {
+      checkRateLimit("9.9.9.9", now);
+    }
+    expect(checkRateLimit("9.9.9.9", now).ok).toBe(false);
+    const later = now + RATE_LIMIT_WINDOW_MS + 1;
+    expect(checkRateLimit("9.9.9.9", later).ok).toBe(true);
+  });
+
+  it("never throttles unidentifiable callers", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < RATE_LIMIT_MAX_HITS * 2; i++) {
+      expect(checkRateLimit("0.0.0.0", now).ok).toBe(true);
+      expect(checkRateLimit("", now).ok).toBe(true);
+    }
+  });
+});

--- a/dify-helm-watchdog/src/test/middleware.test.ts
+++ b/dify-helm-watchdog/src/test/middleware.test.ts
@@ -2,6 +2,7 @@ import { NextRequest, type NextFetchEvent } from "next/server";
 
 import { middleware } from "@/middleware";
 import { trackEvent } from "@/lib/analytics/track";
+import { __resetRateLimit } from "@/lib/api/rate-limit";
 
 jest.mock("@/lib/analytics/track", () => ({
   trackEvent: jest.fn(() => Promise.resolve()),
@@ -40,6 +41,9 @@ describe("middleware", () => {
     // resetAllMocks would strip Promise.resolve() and trackEvent(...).catch()
     // would then throw on undefined.
     jest.clearAllMocks();
+    // The rate limiter holds module-scope state across calls; reset it so
+    // request counts don't leak between tests.
+    __resetRateLimit();
   });
 
   it("tracks homepage via waitUntil as kind=page name=home", async () => {
@@ -106,5 +110,37 @@ describe("middleware", () => {
     mockedTrack.mockRejectedValueOnce(new Error("boom"));
     const evt = buildEvent();
     await expect(middleware(buildReq("/"), evt.fetchEvent)).resolves.toBeDefined();
+  });
+
+  it.each([
+    "/api/v1/versions/%2e%2e%2fetc%2fpasswd/values",
+    "/api/v1/releases/3.10.0%2f..%2f..%2f..%2fblog",
+    "/api/v1/versions/%252f",
+    "/api/v1/releases/localhost:8080",
+    "/api/v1/versions/%00",
+  ])("short-circuits suspicious path %s with 400 and never tracks", async (path) => {
+    const evt = buildEvent();
+    const res = await middleware(buildReq(path), evt.fetchEvent);
+    await flushMicrotasks();
+    expect(res.status).toBe(400);
+    expect(evt.waitUntil).not.toHaveBeenCalled();
+    expect(mockedTrack).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits a single IP past the limit with 429 and stops tracking", async () => {
+    const { RATE_LIMIT_MAX_HITS } = await import("@/lib/api/rate-limit");
+    const evt = buildEvent();
+
+    for (let i = 0; i < RATE_LIMIT_MAX_HITS; i++) {
+      const ok = await middleware(buildReq("/api/v1/versions"), evt.fetchEvent);
+      expect(ok.status).not.toBe(429);
+    }
+    expect(mockedTrack).toHaveBeenCalledTimes(RATE_LIMIT_MAX_HITS);
+
+    const blocked = await middleware(buildReq("/api/v1/versions"), evt.fetchEvent);
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBeTruthy();
+    // No new track call for the throttled request.
+    expect(mockedTrack).toHaveBeenCalledTimes(RATE_LIMIT_MAX_HITS);
   });
 });


### PR DESCRIPTION
## Why

AE analytics flagged a Singapore traffic spike on **2026-06-11** (477 hits, 400 in the 20:00 UTC hour). Drill-down showed it was an **automated vulnerability scanner**, not real users — 124 hits carried attack payloads:

- **Path traversal**: `..`, `%2e%2e`, `%2f`, double-encoded `%252f`, overlong UTF-8 `%c0%af`
- **SSRF / metadata**: `169.254.169.254/...`, `localhost:8080`, `kubernetes.default.svc.cluster.local`, `...%40169.254.169.254`
- **LFI**: `etc/passwd`
- **CRLF**: `%0d%0a`

None succeeded (params are looked up as strings → 404), but **each request still cost money**: the middleware fires an outbound `trackEvent()` fetch (kept alive by `waitUntil`), and the `versions/[version]*` routes call `loadCache()` (R2 read + enrichment) *before* validating the version param. A sustained burst inflates Vercel function-invocation + R2 costs.

## What

Three cheap layers, **no new dependencies**:

1. **Edge path guard** — `src/lib/api/guard.ts` + `src/middleware.ts`. The middleware is the single chokepoint for every `/api/v1/*` request; it now short-circuits traversal/SSRF/LFI/CRLF paths with an empty `400` *before* `trackEvent` and *before* the route function. Returning a non-`next()` response stops the downstream function (and its R2 reads) from ever running, and skips the analytics fetch. Tested against the raw, still-encoded path so `%2e`/`%252f`/`%c0%af` stay visible.

2. **Early version validation** — the four `versions/[version]*` routes reject malformed versions before `loadCache()`, mirroring the existing `releases/[version]` route. All five now share one canonical `isValidVersion()` (anchored SemVer + prerelease/build).

3. **Best-effort rate limiting** — `src/lib/api/rate-limit.ts`. Per-IP in-memory sliding window, env-tunable (`RATE_LIMIT_MAX` default 100, `RATE_LIMIT_WINDOW_S` default 60), returns `429` with `Retry-After`. Unidentifiable callers are never throttled.

### ⚠️ Honest limitation of the rate limiter
Vercel runs many ephemeral instances, so the in-memory counter is **per-instance best-effort**, not a global cap. It throttles a single aggressive client hitting a warm instance at zero cost, but it is **not** a hard bill ceiling.

## Recommended dashboard follow-ups (not code)
- **Vercel Firewall / WAF**: deny rules for these path patterns + edge rate limiting. WAF denies happen *before* any function bills — the only truly-free block.
- **Vercel Spend Management**: budget + alert/pause action as the financial backstop.

## Tests
- `src/test/lib/api/guard.test.ts` — attack paths flagged, legit paths pass; version validator accepts/rejects.
- `src/test/lib/api/rate-limit.test.ts` — allow→deny at limit, per-key isolation, window reset, unknown-IP skip.
- `src/test/middleware.test.ts` — suspicious path → 400 + no track; over-limit → 429 + no track; legit paths still track.
- four `versions/[version]*` route tests — malformed version → 400 **without** `loadCache()`.

`yarn lint`, `yarn test` (189 passing), and `tsc --noEmit` all clean.