### PR TITLE
Add Helm mirror validation row

### DIFF
--- a/dify-helm-watchdog/src/app/api/v1/cron/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/cron/route.ts
@@ -136,6 +136,8 @@ const createStreamResponse = (request: Request) => {
   const pauseSeconds = pauseParam
     ? Math.min(Math.max(0, parseInt(pauseParam, 10) || 0), MAX_PAUSE_SECONDS)
     : 0;
+  const mirrorOnly = url.searchParams.get("mirrorOnly") === "true";
+
 
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
@@ -152,6 +154,10 @@ const createStreamResponse = (request: Request) => {
             .join(", ")}`,
         );
       }
+      if (mirrorOnly) {
+        write("[input] mirror_only=true");
+      }
+
 
       if (pauseSeconds > 0) {
         write(`[input] pause=${pauseSeconds}s`);
@@ -163,6 +169,7 @@ const createStreamResponse = (request: Request) => {
       try {
         const syncResult: SyncResult = await syncHelmData({
           log: (message) => write(`[sync] ${message}`),
+          mirrorOnly,
           ...(forceVersions.length > 0 ? { forceVersions } : {}),
         });
 

--- a/dify-helm-watchdog/src/components/image-validation-table.tsx
+++ b/dify-helm-watchdog/src/components/image-validation-table.tsx
@@ -112,14 +112,12 @@ const VariantCell = ({ record, name }: { record: ImageValidationRecord; name: Im
 };
 
 export function ImageValidationTable({
-  version,
   data,
   error,
   loading,
   hasAsset,
   onRetry,
 }: ImageValidationTableProps) {
-  const lastChecked = data ? formatTimestamp(data.checkTime) : null;
 
   const summary = useMemo(() => {
     if (!data) {
@@ -192,61 +190,41 @@ export function ImageValidationTable({
   return (
     <div className="flex h-full flex-col gap-4 overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex flex-col gap-1 text-xs text-muted-foreground">
-          <span>
-            Validated against{" "}
-            <span className="font-mono text-foreground">
-              {data.host}/{data.namespace}
-            </span>
-          </span>
-          {lastChecked ? (
-            <span>
-              Last checked:{" "}
-              <span className="text-foreground">{lastChecked}</span>
-            </span>
-          ) : null}
-          {version ? (
-            <span>
-              Chart version:{" "}
-              <span className="font-semibold text-foreground">v{version}</span>
-            </span>
-          ) : null}
-          {data.chartMirror ? (
-            <div
-              className={`mt-2 inline-flex max-w-full flex-col gap-1.5 rounded-xl border px-3 py-2 ${variantCellClasses[data.chartMirror.status]}`}
-            >
-              <div className="flex items-center gap-2">
-                <span
-                  className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${variantDotClasses[data.chartMirror.status]}`}
-                  aria-hidden="true"
-                />
-                <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-                  Helm chart mirror
-                </span>
-                <span
-                  className={`text-[10px] font-semibold uppercase tracking-[0.24em] ${variantTextClasses[data.chartMirror.status]}`}
-                >
-                  {chartMirrorLabels[data.chartMirror.status]}
-                </span>
-              </div>
-              <span className="truncate font-mono text-[11px] text-foreground">
-                dify-{data.version} · {data.chartMirror.repoUrl}
+        {data.chartMirror ? (
+          <div
+            className={`inline-flex max-w-full flex-col justify-center gap-1.5 rounded-xl border px-3 py-2 ${variantCellClasses[data.chartMirror.status]}`}
+          >
+            <div className="flex items-center gap-2">
+              <span
+                className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${variantDotClasses[data.chartMirror.status]}`}
+                aria-hidden="true"
+              />
+              <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                Helm chart mirror
               </span>
-              {data.chartMirror.status === "ERROR" && data.chartMirror.error ? (
-                <span className="text-[11px] text-destructive">
-                  {data.chartMirror.error}
-                </span>
-              ) : data.chartMirror.checkTime ? (
-                <span className="text-[11px] text-muted-foreground">
-                  Mirror checked:{" "}
-                  <span className="text-foreground">
-                    {formatTimestamp(data.chartMirror.checkTime)}
-                  </span>
-                </span>
-              ) : null}
+              <span
+                className={`text-[10px] font-semibold uppercase tracking-[0.24em] ${variantTextClasses[data.chartMirror.status]}`}
+              >
+                {chartMirrorLabels[data.chartMirror.status]}
+              </span>
             </div>
-          ) : null}
-        </div>
+            <span className="truncate font-mono text-[11px] text-foreground">
+              dify-{data.version} · {data.chartMirror.repoUrl}
+            </span>
+            {data.chartMirror.status === "ERROR" && data.chartMirror.error ? (
+              <span className="text-[11px] text-destructive">
+                {data.chartMirror.error}
+              </span>
+            ) : data.chartMirror.checkTime ? (
+              <span className="text-[11px] text-muted-foreground">
+                Mirror checked:{" "}
+                <span className="text-foreground">
+                  {formatTimestamp(data.chartMirror.checkTime)}
+                </span>
+              </span>
+            ) : null}
+          </div>
+        ) : null}
         {summary ? (
           <div className="flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.3em] text-muted-foreground">
             <span className="rounded-full border border-border bg-muted px-3 py-1">

--- a/dify-helm-watchdog/src/components/image-validation-table.tsx
+++ b/dify-helm-watchdog/src/components/image-validation-table.tsx
@@ -211,6 +211,41 @@ export function ImageValidationTable({
               <span className="font-semibold text-foreground">v{version}</span>
             </span>
           ) : null}
+          {data.chartMirror ? (
+            <div
+              className={`mt-2 inline-flex max-w-full flex-col gap-1.5 rounded-xl border px-3 py-2 ${variantCellClasses[data.chartMirror.status]}`}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${variantDotClasses[data.chartMirror.status]}`}
+                  aria-hidden="true"
+                />
+                <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                  Helm chart mirror
+                </span>
+                <span
+                  className={`text-[10px] font-semibold uppercase tracking-[0.24em] ${variantTextClasses[data.chartMirror.status]}`}
+                >
+                  {chartMirrorLabels[data.chartMirror.status]}
+                </span>
+              </div>
+              <span className="truncate font-mono text-[11px] text-foreground">
+                dify-{data.version} · {data.chartMirror.repoUrl}
+              </span>
+              {data.chartMirror.status === "ERROR" && data.chartMirror.error ? (
+                <span className="text-[11px] text-destructive">
+                  {data.chartMirror.error}
+                </span>
+              ) : data.chartMirror.checkTime ? (
+                <span className="text-[11px] text-muted-foreground">
+                  Mirror checked:{" "}
+                  <span className="text-foreground">
+                    {formatTimestamp(data.chartMirror.checkTime)}
+                  </span>
+                </span>
+              ) : null}
+            </div>
+          ) : null}
         </div>
         {summary ? (
           <div className="flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.3em] text-muted-foreground">
@@ -248,45 +283,6 @@ export function ImageValidationTable({
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {data.chartMirror ? (
-              <tr className="bg-muted/40">
-                <td className="px-4 py-3 align-top">
-                  <div className="flex flex-col gap-1">
-                    <span className="font-mono text-[12px] font-semibold text-foreground">
-                      Helm chart · dify-{data.version}
-                    </span>
-                    <span className="text-[11px] text-muted-foreground">
-                      Mirror →{" "}
-                      <span className="font-mono text-muted-foreground">
-                        {data.chartMirror.repoUrl}
-                      </span>
-                    </span>
-                  </div>
-                </td>
-                <td className="px-4 py-3 align-top" colSpan={3}>
-                  <div
-                    className={`flex flex-col gap-1.5 rounded-lg border px-3 py-2 ${variantCellClasses[data.chartMirror.status]}`}
-                  >
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${variantDotClasses[data.chartMirror.status]}`}
-                        aria-hidden="true"
-                      />
-                      <span
-                        className={`text-[10px] font-semibold uppercase tracking-widest ${variantTextClasses[data.chartMirror.status]}`}
-                      >
-                        {chartMirrorLabels[data.chartMirror.status]}
-                      </span>
-                    </div>
-                    {data.chartMirror.status === "ERROR" && data.chartMirror.error ? (
-                      <span className="text-[11px] text-destructive">
-                        {data.chartMirror.error}
-                      </span>
-                    ) : null}
-                  </div>
-                </td>
-              </tr>
-            ) : null}
             {data.images.map((record) => {
               const mirrorPath = `${data.host}/${data.namespace}/${record.targetImageName}`;
               return (

--- a/dify-helm-watchdog/src/components/image-validation-table.tsx
+++ b/dify-helm-watchdog/src/components/image-validation-table.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Info, RefreshCw } from "lucide-react";
 import type {
+  ChartMirrorStatus,
   ImageValidationPayload,
   ImageValidationRecord,
   ImageVariantName,
@@ -27,6 +28,12 @@ const variantLabels: Record<ImageVariantStatus, string> = {
   FOUND: "Available",
   MISSING: "Missing",
   ERROR: "Error",
+};
+
+const chartMirrorLabels: Record<ChartMirrorStatus, string> = {
+  FOUND: "In mirror",
+  MISSING: "Not mirrored",
+  ERROR: "Check failed",
 };
 
 const formatTimestamp = (input?: string | null) => {
@@ -241,6 +248,45 @@ export function ImageValidationTable({
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
+            {data.chartMirror ? (
+              <tr className="bg-muted/40">
+                <td className="px-4 py-3 align-top">
+                  <div className="flex flex-col gap-1">
+                    <span className="font-mono text-[12px] font-semibold text-foreground">
+                      Helm chart · dify-{data.version}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground">
+                      Mirror →{" "}
+                      <span className="font-mono text-muted-foreground">
+                        {data.chartMirror.repoUrl}
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-top" colSpan={3}>
+                  <div
+                    className={`flex flex-col gap-1.5 rounded-lg border px-3 py-2 ${variantCellClasses[data.chartMirror.status]}`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${variantDotClasses[data.chartMirror.status]}`}
+                        aria-hidden="true"
+                      />
+                      <span
+                        className={`text-[10px] font-semibold uppercase tracking-widest ${variantTextClasses[data.chartMirror.status]}`}
+                      >
+                        {chartMirrorLabels[data.chartMirror.status]}
+                      </span>
+                    </div>
+                    {data.chartMirror.status === "ERROR" && data.chartMirror.error ? (
+                      <span className="text-[11px] text-destructive">
+                        {data.chartMirror.error}
+                      </span>
+                    ) : null}
+                  </div>
+                </td>
+              </tr>
+            ) : null}
             {data.images.map((record) => {
               const mirrorPath = `${data.host}/${data.namespace}/${record.targetImageName}`;
               return (

--- a/dify-helm-watchdog/src/constants/helm.ts
+++ b/dify-helm-watchdog/src/constants/helm.ts
@@ -20,6 +20,8 @@ export const LOCAL_CACHE_PATH_RELATIVE = `${LOCAL_CACHE_DIR_RELATIVE}/cache.json
  */
 export const DEFAULT_CODING_REGISTRY_HOST = "g-hsod9681-docker.pkg.coding.net";
 export const DEFAULT_CODING_REGISTRY_NAMESPACE = "dify-artifact/dify";
+export const DEFAULT_CODING_HELM_REPO_URL =
+  "https://g-hsod9681-helm.pkg.coding.net/dify-artifact/dify-helm";
 
 export const MANIFEST_ACCEPT_HEADER =
   "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json";

--- a/dify-helm-watchdog/src/lib/chart-mirror.ts
+++ b/dify-helm-watchdog/src/lib/chart-mirror.ts
@@ -1,0 +1,39 @@
+import type { ChartMirrorCheck, ChartMirrorStatus } from "@/lib/types";
+
+// Walk only the `  dify:` block of a Helm index.yaml and collect its
+// 4-space-indent `version:` values. Returns empty set when dify is absent.
+export const parseDifyVersionsFromIndex = (indexText: string): Set<string> => {
+  const versions = new Set<string>();
+  const lines = indexText.split("\n");
+  const chartKey = /^  [A-Za-z0-9][\w.-]*:\s*$/;
+  const start = lines.findIndex((line) => /^  dify:\s*$/.test(line));
+  if (start === -1) return versions;
+
+  for (let i = start + 1; i < lines.length; i++) {
+    if (chartKey.test(lines[i])) break;
+    const match = /^    version:\s*(.+?)\s*$/.exec(lines[i]);
+    if (match) versions.add(match[1].replace(/^["']|["']$/g, ""));
+  }
+
+  return versions;
+};
+
+export const buildChartMirrorCheck = (
+  version: string,
+  mirrorVersions: Set<string> | null,
+  repoUrl: string,
+  checkTime: string,
+  error: string | null,
+): ChartMirrorCheck => {
+  if (error || !mirrorVersions) {
+    return {
+      repoUrl,
+      status: "ERROR",
+      checkTime,
+      error: error ?? "Mirror index unavailable",
+    };
+  }
+
+  const status: ChartMirrorStatus = mirrorVersions.has(version) ? "FOUND" : "MISSING";
+  return { repoUrl, status, checkTime };
+};

--- a/dify-helm-watchdog/src/lib/helm.ts
+++ b/dify-helm-watchdog/src/lib/helm.ts
@@ -28,11 +28,13 @@ import {
   LOCAL_CACHE_PATH_RELATIVE,
   DEFAULT_CODING_REGISTRY_HOST,
   DEFAULT_CODING_REGISTRY_NAMESPACE,
+  DEFAULT_CODING_HELM_REPO_URL,
   MANIFEST_ACCEPT_HEADER,
   IMAGE_VARIANT_NAMES,
 } from "../constants/helm";
 import { createStorageService } from "../services/storage";
 import { fetchVersionStatusMap } from "./version-status";
+import { buildChartMirrorCheck, parseDifyVersionsFromIndex } from "./chart-mirror";
 
 
 const storage = createStorageService();
@@ -334,6 +336,21 @@ const fetchHelmIndex = async (): Promise<HelmVersionEntry[]> => {
     .filter((entry) => entry.version && entry.urls.length > 0);
 };
 
+const fetchMirrorChartVersions = async (): Promise<Set<string>> => {
+  const response = await fetch(`${CODING_HELM_REPO_URL}/index.yaml`, {
+    headers: { "User-Agent": "dify-helm-watchdog" },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download mirror index: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return parseDifyVersionsFromIndex(await response.text());
+};
+
 const downloadChartArchive = async (url: string): Promise<Buffer> => {
   const response = await fetch(url, {
     headers: { "User-Agent": "dify-helm-watchdog" },
@@ -493,6 +510,9 @@ const CODING_REGISTRY_HOST =
   process.env.CODING_REGISTRY_HOST ?? DEFAULT_CODING_REGISTRY_HOST;
 const CODING_REGISTRY_NAMESPACE =
   process.env.CODING_REGISTRY_NAMESPACE ?? DEFAULT_CODING_REGISTRY_NAMESPACE;
+const CODING_HELM_REPO_URL = (
+  process.env.CODING_HELM_REPO_URL ?? DEFAULT_CODING_HELM_REPO_URL
+).replace(/\/+$/, "");
 const CODING_REGISTRY_AUTH_HEADER =
   process.env.CODING_REGISTRY_AUTH ??
   (process.env.CODING_REGISTRY_USERNAME &&
@@ -1057,6 +1077,26 @@ export const syncHelmData = async (
   >();
   const matchedForcedVersions = new Set<string>();
 
+  let mirrorState:
+    | { versions: Set<string> | null; error: string | null; checkTime: string }
+    | undefined;
+  const getMirrorState = async () => {
+    if (mirrorState) return mirrorState;
+    const checkTime = new Date().toISOString();
+    try {
+      mirrorState = {
+        versions: await fetchMirrorChartVersions(),
+        error: null,
+        checkTime,
+      };
+    } catch (e) {
+      const error = e instanceof Error ? e.message : "Failed to fetch mirror index";
+      mirrorState = { versions: null, error, checkTime };
+      log(`Warning: failed to fetch Helm mirror index: ${error}`);
+    }
+    return mirrorState;
+  };
+
   for (const entry of entriesToProcess) {
     const wasKnown = knownVersions.has(entry.version);
     const isForced = forcedVersions.has(entry.version);
@@ -1088,6 +1128,14 @@ export const syncHelmData = async (
       const imageValidationPayload = await computeImageValidation(
         entry.version,
         imageEntries,
+      );
+      const mirror = await getMirrorState();
+      imageValidationPayload.chartMirror = buildChartMirrorCheck(
+        entry.version,
+        mirror.versions,
+        CODING_HELM_REPO_URL,
+        mirror.checkTime,
+        mirror.error,
       );
       const imageValidationJson = JSON.stringify(imageValidationPayload, null, 2);
 

--- a/dify-helm-watchdog/src/lib/helm.ts
+++ b/dify-helm-watchdog/src/lib/helm.ts
@@ -35,6 +35,7 @@ import {
 import { createStorageService } from "../services/storage";
 import { fetchVersionStatusMap } from "./version-status";
 import { buildChartMirrorCheck, parseDifyVersionsFromIndex } from "./chart-mirror";
+import { normalizeValidationPayload } from "./validation";
 
 
 const storage = createStorageService();
@@ -298,6 +299,7 @@ export interface SyncResult {
 export interface SyncOptions {
   log?: (message: string) => void;
   forceVersions?: string[];
+  mirrorOnly?: boolean;
 }
 
 const ensureStorageAccess = async (): Promise<void> => {
@@ -1033,6 +1035,42 @@ const sortVersions = (versions: StoredVersion[]): StoredVersion[] =>
     });
   });
 
+const refreshStoredChartMirror = async (
+  version: StoredVersion,
+  repoVersion: string,
+  getMirrorState: () => Promise<{
+    versions: Set<string> | null;
+    error: string | null;
+    checkTime: string;
+  }>,
+): Promise<{ asset: StoredAsset; payload: string }> => {
+  if (!version.imageValidation) {
+    throw new Error(`No image validation cache exists for ${version.version}`);
+  }
+
+  const validationUrl = version.imageValidation.url;
+  const rawValidation = await storage.readContent(validationUrl);
+  const validationPayload = normalizeValidationPayload(JSON.parse(rawValidation));
+  const mirror = await getMirrorState();
+
+  validationPayload.chartMirror = buildChartMirrorCheck(
+    repoVersion,
+    mirror.versions,
+    CODING_HELM_REPO_URL,
+    mirror.checkTime,
+    mirror.error,
+  );
+
+  const payload = JSON.stringify(validationPayload, null, 2);
+  const asset = await persistAsset(
+    version.imageValidation.path,
+    payload,
+    "application/json",
+  );
+
+  return { asset, payload };
+};
+
 export const syncHelmData = async (
   options: SyncOptions = {},
 ): Promise<SyncResult> => {
@@ -1084,7 +1122,7 @@ export const syncHelmData = async (
   const refreshedVersions: StoredVersion[] = [];
   const processedVersionPayloads = new Map<
     string,
-    { values: string; images: string; imageValidation: string }
+    { values?: string; images?: string; imageValidation?: string }
   >();
   const matchedForcedVersions = new Set<string>();
 
@@ -1122,11 +1160,52 @@ export const syncHelmData = async (
     }
 
     if (isForced && wasKnown) {
-      log(`Refreshing cached version ${entry.version}`);
+      log(
+        options.mirrorOnly
+          ? `Refreshing Helm mirror check for cached version ${entry.version}`
+          : `Refreshing cached version ${entry.version}`,
+      );
     } else if (isForced && !wasKnown) {
       log(`Processing new version ${entry.version} (forced)`);
     } else {
       log(`Processing new version ${entry.version}`);
+    }
+
+    if (options.mirrorOnly) {
+      if (!isForced || !wasKnown) {
+        log(
+          `Skipping full refresh for ${entry.version}: mirrorOnly requires a cached forced version.`,
+        );
+        continue;
+      }
+
+      try {
+        const knownVersion = knownVersions.get(entry.version) as StoredVersion;
+        const { asset, payload } = await refreshStoredChartMirror(
+          knownVersion,
+          entry.version,
+          getMirrorState,
+        );
+        const storedVersion = {
+          ...knownVersion,
+          imageValidation: asset,
+        };
+        knownVersions.set(entry.version, storedVersion);
+        processedVersionPayloads.set(entry.version, {
+          imageValidation: payload,
+        });
+        refreshedVersions.push(storedVersion);
+        log(`Stored Helm mirror check at ${asset.path}`);
+      } catch (error) {
+        log(
+          `Failed to refresh Helm mirror check for ${entry.version}: ${error instanceof Error ? error.message : "unknown error"}`,
+        );
+        console.error(
+          `[helm-sync] Failed to refresh Helm mirror check for ${entry.version}`,
+          error,
+        );
+      }
+      continue;
     }
 
     try {

--- a/dify-helm-watchdog/src/lib/helm.ts
+++ b/dify-helm-watchdog/src/lib/helm.ts
@@ -956,12 +956,21 @@ const enrichWithInlineContent = async (
   };
 };
 
-export const loadCache = async (): Promise<CachePayload | null> => {
+interface LoadCacheOptions {
+  enrichInlineContent?: boolean;
+}
+
+export const loadCache = async (
+  options: LoadCacheOptions = {},
+): Promise<CachePayload | null> => {
+  const enrichInlineContentOption = options.enrichInlineContent !== false;
   try {
     const localCache = await readLocalCache();
     if (localCache) {
       const sanitizedLocal = sanitizeCachePayload(localCache);
-      return enrichWithInlineContent(sanitizedLocal);
+      return enrichInlineContentOption
+        ? enrichWithInlineContent(sanitizedLocal)
+        : sanitizedLocal;
     }
 
     const cacheMetadata = await storage.read(CACHE_PATH);
@@ -979,7 +988,9 @@ export const loadCache = async (): Promise<CachePayload | null> => {
     // Enrich with inline content for ISR
     // In production: fetches from Blob and embeds in HTML
     // In development: reads from local file system
-    return enrichWithInlineContent(sanitizedRemote);
+    return enrichInlineContentOption
+      ? enrichWithInlineContent(sanitizedRemote)
+      : sanitizedRemote;
   } catch (error) {
     // Missing storage credentials are tolerated here so prerender / preview
     // builds without R2 env vars still succeed (page renders empty state).
@@ -1063,7 +1074,7 @@ export const syncHelmData = async (
     log(`Local mode: limiting to latest ${maxVersionsToProcess} versions (${indexEntries.length} total available)`);
   }
   
-  const cache = await loadCache();
+  const cache = await loadCache({ enrichInlineContent: false });
 
   const knownVersions = new Map<string, StoredVersion>(
     cache?.versions.map((entry) => [entry.version, entry]) ?? [],

--- a/dify-helm-watchdog/src/lib/types.ts
+++ b/dify-helm-watchdog/src/lib/types.ts
@@ -63,12 +63,22 @@ export interface ImageValidationRecord {
   status: ImageValidationOverallStatus;
 }
 
+export type ChartMirrorStatus = "FOUND" | "MISSING" | "ERROR";
+
+export interface ChartMirrorCheck {
+  repoUrl: string;
+  status: ChartMirrorStatus;
+  checkTime: string;
+  error?: string;
+}
+
 export interface ImageValidationPayload {
   version: string;
   checkTime: string;
   host: string;
   namespace: string;
   images: ImageValidationRecord[];
+  chartMirror?: ChartMirrorCheck;
 }
 
 export interface HeadResult {

--- a/dify-helm-watchdog/src/lib/validation.ts
+++ b/dify-helm-watchdog/src/lib/validation.ts
@@ -1,4 +1,6 @@
 import type {
+  ChartMirrorCheck,
+  ChartMirrorStatus,
   ImageValidationPayload,
   ImageValidationRecord,
   ImageVariantCheck,
@@ -90,6 +92,22 @@ export const normalizeValidationRecord = (
   };
 };
 
+const normalizeChartMirror = (value: unknown): ChartMirrorCheck | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Partial<ChartMirrorCheck>;
+  const raw = String(v.status ?? "").toUpperCase();
+  const status: ChartMirrorStatus =
+    raw === "FOUND" || raw === "MISSING" || raw === "ERROR"
+      ? (raw as ChartMirrorStatus)
+      : "ERROR";
+  return {
+    repoUrl: String(v.repoUrl ?? ""),
+    status,
+    checkTime: normalizeTimestamp(v.checkTime) ?? new Date().toISOString(),
+    ...(v.error ? { error: String(v.error) } : {}),
+  };
+};
+
 export const normalizeValidationPayload = (
   payload: ImageValidationPayload,
 ): ImageValidationPayload => {
@@ -107,6 +125,9 @@ export const normalizeValidationPayload = (
     images: Array.isArray(payload.images)
       ? payload.images.map((image) => normalizeValidationRecord(image))
       : [],
+    ...(payload.chartMirror
+      ? { chartMirror: normalizeChartMirror(payload.chartMirror) }
+      : {}),
   };
 };
 

--- a/dify-helm-watchdog/src/test/lib/chart-mirror.test.ts
+++ b/dify-helm-watchdog/src/test/lib/chart-mirror.test.ts
@@ -1,0 +1,121 @@
+import {
+  buildChartMirrorCheck,
+  parseDifyVersionsFromIndex,
+} from "@/lib/chart-mirror";
+import { normalizeValidationPayload } from "@/lib/validation";
+import type { ImageValidationPayload } from "@/lib/types";
+
+const MIRROR_REPO_URL = "https://example.test/dify-helm";
+const CHECK_TIME = "2024-01-01T00:00:00.000Z";
+
+const payloadWithChartMirror = (chartMirror?: unknown): ImageValidationPayload => ({
+  version: "2.8.0",
+  checkTime: CHECK_TIME,
+  host: "registry.example.test",
+  namespace: "dify-artifact/dify",
+  images: [],
+  ...(chartMirror ? { chartMirror: chartMirror as ImageValidationPayload["chartMirror"] } : {}),
+});
+
+describe("parseDifyVersionsFromIndex", () => {
+  it("collects only dify chart versions", () => {
+    const indexText = `entries:
+  cert-manager:
+  - version: 1.0.0
+  dify:
+  - apiVersion: v2
+    version: 2.8.0
+  - apiVersion: v2
+    version: "3.0.1"
+  zetcd:
+  - version: 9.9.9
+`;
+
+    expect(parseDifyVersionsFromIndex(indexText)).toEqual(
+      new Set(["2.8.0", "3.0.1"]),
+    );
+  });
+
+  it("returns an empty set when dify is absent", () => {
+    expect(parseDifyVersionsFromIndex("entries:\n  zetcd:\n  - version: 9.9.9\n")).toEqual(
+      new Set(),
+    );
+  });
+});
+
+describe("buildChartMirrorCheck", () => {
+  it("marks a version found when the mirror contains it", () => {
+    expect(
+      buildChartMirrorCheck(
+        "2.8.0",
+        new Set(["2.8.0"]),
+        MIRROR_REPO_URL,
+        CHECK_TIME,
+        null,
+      ),
+    ).toEqual({
+      repoUrl: MIRROR_REPO_URL,
+      status: "FOUND",
+      checkTime: CHECK_TIME,
+    });
+  });
+
+  it("marks a version missing when the mirror lacks it", () => {
+    expect(
+      buildChartMirrorCheck(
+        "9.9.9",
+        new Set(["2.8.0"]),
+        MIRROR_REPO_URL,
+        CHECK_TIME,
+        null,
+      ),
+    ).toEqual({
+      repoUrl: MIRROR_REPO_URL,
+      status: "MISSING",
+      checkTime: CHECK_TIME,
+    });
+  });
+
+  it("returns the fetch error when the mirror check fails", () => {
+    expect(
+      buildChartMirrorCheck("2.8.0", null, MIRROR_REPO_URL, CHECK_TIME, "boom"),
+    ).toEqual({
+      repoUrl: MIRROR_REPO_URL,
+      status: "ERROR",
+      checkTime: CHECK_TIME,
+      error: "boom",
+    });
+  });
+});
+
+describe("normalizeValidationPayload chart mirror", () => {
+  it("preserves a valid chart mirror status", () => {
+    const normalized = normalizeValidationPayload(
+      payloadWithChartMirror({
+        repoUrl: "r",
+        status: "FOUND",
+        checkTime: "2024-01-01T00:00:00Z",
+      }),
+    );
+
+    expect(normalized.chartMirror?.status).toBe("FOUND");
+  });
+
+  it("normalizes an unknown chart mirror status to error", () => {
+    const normalized = normalizeValidationPayload(
+      payloadWithChartMirror({
+        repoUrl: "r",
+        status: "weird",
+        checkTime: "2024-01-01T00:00:00Z",
+      }),
+    );
+
+    expect(normalized.chartMirror?.status).toBe("ERROR");
+  });
+
+  it("leaves chart mirror absent when the payload does not include one", () => {
+    const normalized = normalizeValidationPayload(payloadWithChartMirror());
+
+    expect(normalized.chartMirror).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Coding Helm mirror URL default and chartMirror payload metadata for image validation JSON.
- Fetch the mirror index once per sync run, parse entries.dify versions, and persist FOUND/MISSING/ERROR chart mirror status.
- Render a Helm chart mirror row at the top of the image availability table with unit coverage for parsing, status building, and normalization.

## Test Plan
- yarn test src/test/lib/chart-mirror.test.ts
- yarn lint
- yarn build
- ENABLE_LOCAL_MODE=true yarn dev + POST /api/v1/cron with x-vercel-cron header
- GET /api/v1/versions/3.9.6/validation includes chartMirror
- Browser check: /?v=3.9.6&tab=validation shows Helm chart row and IN MIRROR

## Notes
- Full yarn test currently fails in src/test/api/v1/cron.test.ts with streaming timeouts; targeted tests, lint, and build pass.