### PR TITLE
[codex] add release lock source refs

### DIFF
--- a/dify-helm-watchdog/.gitignore
+++ b/dify-helm-watchdog/.gitignore
@@ -43,6 +43,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+scripts/.sync-ee-release-locks.env
 
 # vercel
 .vercel

--- a/dify-helm-watchdog/scripts/sync-ee-release-locks-to-r2.sh
+++ b/dify-helm-watchdog/scripts/sync-ee-release-locks-to-r2.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run this on a machine whose GitHub identity can read langgenius/ee-release.
+# Requires:
+#   - gh
+#   - either awscli + R2 S3 keys, or wrangler + CLOUDFLARE_API_TOKEN
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${EE_RELEASE_LOCKS_ENV:-$SCRIPT_DIR/.sync-ee-release-locks.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+fi
+
+OWNER="${EE_RELEASE_OWNER:-langgenius}"
+REPO="${EE_RELEASE_REPO:-ee-release}"
+PREFIX="${EE_RELEASE_LOCKS_PREFIX:-helm-watchdog/release-locks}"
+
+DRY_RUN=""
+FORCE=""
+while (($#)); do
+  case "$1" in
+    --dry-run)
+      DRY_RUN="--dryrun"
+      shift
+      ;;
+    --force)
+      FORCE="1"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if (($#)); then
+  versions=("$@")
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "missing gh; install GitHub CLI and run gh auth login" >&2
+    exit 1
+  fi
+
+  versions=()
+  while IFS= read -r version; do
+    versions+=("$version")
+  done < <(
+    gh api "repos/$OWNER/$REPO/tags" --paginate --jq '.[].name' |
+      awk -F. '{
+        major = $1
+        sub(/^v/, "", major)
+        if ((major + 0 > 3 || (major + 0 == 3 && $2 + 0 >= 9)) && $3 ~ /^[0-9]+$/) print $0
+      }'
+  )
+fi
+
+if ((${#versions[@]} == 0)); then
+  echo "no release tags found; check GitHub auth for $OWNER/$REPO" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+with_cloudflare_account() {
+  export CLOUDFLARE_ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-${R2_ACCOUNT_ID:-}}"
+  if [[ -z "$CLOUDFLARE_ACCOUNT_ID" ]]; then
+    echo "missing CLOUDFLARE_ACCOUNT_ID or R2_ACCOUNT_ID" >&2
+    exit 1
+  fi
+}
+
+object_exists() {
+  local key="$1"
+
+  if [[ -n "${R2_PUBLIC_BASE_URL:-}" ]]; then
+    curl -fsI "${R2_PUBLIC_BASE_URL%/}/$key" >/dev/null 2>&1
+    return
+  fi
+
+  if [[ -n "${R2_ACCESS_KEY_ID:-}" && -n "${R2_SECRET_ACCESS_KEY:-}" ]]; then
+    export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$R2_ACCESS_KEY_ID}"
+    export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$R2_SECRET_ACCESS_KEY}"
+    export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-auto}"
+    local endpoint="${R2_ENDPOINT:-https://${R2_ACCOUNT_ID:?missing R2_ACCOUNT_ID}.r2.cloudflarestorage.com}"
+    aws --endpoint-url "$endpoint" s3api head-object \
+      --bucket "${R2_BUCKET:?missing R2_BUCKET}" \
+      --key "$key" >/dev/null 2>&1
+    return
+  fi
+
+  if [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+    with_cloudflare_account
+    wrangler r2 object get "${R2_BUCKET:?missing R2_BUCKET}/$key" \
+      --pipe \
+      --remote >/dev/null 2>&1
+    return
+  fi
+
+  return 1
+}
+
+upload() {
+  local file="$1"
+  local key="$2"
+
+  if [[ -n "${R2_ACCESS_KEY_ID:-}" && -n "${R2_SECRET_ACCESS_KEY:-}" ]]; then
+    export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$R2_ACCESS_KEY_ID}"
+    export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$R2_SECRET_ACCESS_KEY}"
+    export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-auto}"
+    local endpoint="${R2_ENDPOINT:-https://${R2_ACCOUNT_ID:?missing R2_ACCOUNT_ID}.r2.cloudflarestorage.com}"
+    aws --endpoint-url "$endpoint" s3 cp "$file" \
+      "s3://${R2_BUCKET:?missing R2_BUCKET}/$key" \
+      --content-type application/yaml \
+      $DRY_RUN
+    return
+  fi
+
+  if [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+    with_cloudflare_account
+    if [[ -n "$DRY_RUN" ]]; then
+      echo "[dry-run] wrangler r2 object put ${R2_BUCKET:?missing R2_BUCKET}/$key"
+      return
+    fi
+    wrangler r2 object put "${R2_BUCKET:?missing R2_BUCKET}/$key" \
+      --file "$file" \
+      --content-type application/yaml \
+      --remote
+    return
+  fi
+
+  echo "missing R2 credentials: set R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY or CLOUDFLARE_API_TOKEN" >&2
+  exit 1
+}
+
+seen=0
+skipped=0
+synced=0
+
+for version in "${versions[@]}"; do
+  ((seen += 1))
+  clean_version="${version#v}"
+  key="$PREFIX/$clean_version.yaml"
+
+  if [[ -z "$FORCE" ]] && object_exists "$key"; then
+    ((skipped += 1))
+    echo "[skip] $version already synced"
+    continue
+  fi
+
+  if [[ -n "$DRY_RUN" ]]; then
+    echo "[dry-run] sync $version -> $key"
+    continue
+  fi
+
+  echo "[sync] $version -> $key"
+  out="$tmpdir/$clean_version.yaml"
+  gh api "repos/$OWNER/$REPO/contents/versions.lock.yaml?ref=$version" \
+    -H "Accept: application/vnd.github.raw" >"$out"
+
+  upload "$out" "$key"
+  ((synced += 1))
+done
+
+echo "[done] checked=$seen skipped=$skipped synced=$synced"

--- a/dify-helm-watchdog/src/app/api/v1/versions/[version]/release-lock/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/[version]/release-lock/route.ts
@@ -1,0 +1,98 @@
+import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
+import { isValidVersion } from "@/lib/api/guard";
+import { loadCache } from "@/lib/helm";
+import { loadReleaseLock } from "@/lib/release-locks";
+
+export const runtime = "nodejs";
+
+/**
+ * @swagger
+ * /api/v1/versions/{version}/release-lock:
+ *   get:
+ *     summary: Get release lock source refs
+ *     description: Returns parsed enterprise release lock source references for one chart version.
+ *     tags:
+ *       - Versions
+ *     parameters:
+ *       - name: version
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Parsed release lock payload.
+ *       404:
+ *         description: Version or release lock not available.
+ *       500:
+ *         description: Internal server error.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ version: string }> },
+) {
+  try {
+    const { version } = await params;
+
+    if (!isValidVersion(version)) {
+      return createErrorResponse({
+        request,
+        status: 400,
+        message: `Invalid version format: ${version}`,
+        statusText: "INVALID_ARGUMENT",
+      });
+    }
+
+    const cache = await loadCache();
+    if (!cache) {
+      return createErrorResponse({
+        request,
+        status: 404,
+        message: "Cache not available. Trigger the cron job first.",
+        details: [{ reason: "CACHE_NOT_INITIALIZED" }],
+      });
+    }
+
+    if (!cache.versions.some((entry) => entry.version === version)) {
+      return createErrorResponse({
+        request,
+        status: 404,
+        message: `Version ${version} does not exist in the cache.`,
+        details: [
+          {
+            reason: "VERSION_NOT_FOUND",
+            availableVersions: cache.versions.map((entry) => entry.version),
+          },
+        ],
+      });
+    }
+
+    const releaseLock = await loadReleaseLock(version);
+    if (!releaseLock) {
+      return createErrorResponse({
+        request,
+        status: 404,
+        message: `Release lock is not available for version ${version}.`,
+        details: [{ reason: "RELEASE_LOCK_NOT_AVAILABLE" }],
+      });
+    }
+
+    return createJsonResponse(releaseLock, {
+      request,
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error) {
+    console.error(
+      "[api/v1/versions/{version}/release-lock] Failed to load release lock",
+      error,
+    );
+    return createErrorResponse({
+      request,
+      status: 500,
+      message: error instanceof Error ? error.message : "Unknown error",
+      statusText: "INTERNAL",
+    });
+  }
+}

--- a/dify-helm-watchdog/src/app/api/v1/versions/[version]/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/[version]/route.ts
@@ -1,6 +1,7 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
 import { isValidVersion } from "@/lib/api/guard";
 import { loadCache } from "@/lib/helm";
+import { loadReleaseLock, supportsReleaseLock } from "@/lib/release-locks";
 import { isSkippable } from "@/lib/version-status";
 
 export const runtime = "nodejs";
@@ -72,6 +73,16 @@ export async function GET(
       });
     }
 
+    let releaseLock = null;
+    try {
+      releaseLock = await loadReleaseLock(version);
+    } catch (error) {
+      console.warn(
+        `[api/v1/versions/{version}] Failed to load release lock for ${version}`,
+        error,
+      );
+    }
+
     const responseBody = {
       version: versionEntry.version,
       appVersion: versionEntry.appVersion ?? null,
@@ -105,10 +116,14 @@ export async function GET(
         self: `/api/v1/versions/${version}`,
         images: `/api/v1/versions/${version}/images`,
         values: `/api/v1/versions/${version}/values`,
+        ...(supportsReleaseLock(version)
+          ? { releaseLock: `/api/v1/versions/${version}/release-lock` }
+          : {}),
         ...(versionEntry.imageValidation
           ? { validation: `/api/v1/versions/${version}/validation` }
           : {}),
       },
+      releaseLock,
     };
 
     return createJsonResponse(responseBody, {
@@ -127,4 +142,3 @@ export async function GET(
     });
   }
 }
-

--- a/dify-helm-watchdog/src/app/api/v1/versions/latest/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/latest/route.ts
@@ -1,5 +1,6 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
 import { loadCache } from "@/lib/helm";
+import { supportsReleaseLock } from "@/lib/release-locks";
 import { isSkippable } from "@/lib/version-status";
 
 export const runtime = "nodejs";
@@ -70,6 +71,9 @@ export async function GET(request: Request) {
         self: `/api/v1/versions/${latestVersion.version}`,
         images: `/api/v1/versions/${latestVersion.version}/images`,
         values: `/api/v1/versions/${latestVersion.version}/values`,
+        ...(supportsReleaseLock(latestVersion.version)
+          ? { releaseLock: `/api/v1/versions/${latestVersion.version}/release-lock` }
+          : {}),
         ...(latestVersion.imageValidation
           ? { validation: `/api/v1/versions/${latestVersion.version}/validation` }
           : {}),
@@ -92,4 +96,3 @@ export async function GET(request: Request) {
     });
   }
 }
-

--- a/dify-helm-watchdog/src/app/api/v1/versions/route.ts
+++ b/dify-helm-watchdog/src/app/api/v1/versions/route.ts
@@ -1,5 +1,6 @@
 import { createErrorResponse, createJsonResponse } from "@/lib/api/response";
 import { loadCache } from "@/lib/helm";
+import { supportsReleaseLock } from "@/lib/release-locks";
 import type { ImageValidationRecord, StoredVersion, VersionStatus } from "@/lib/types";
 import { countValidationStatuses } from "@/lib/validation";
 import { isSkippable } from "@/lib/version-status";
@@ -13,6 +14,9 @@ interface VersionSummary {
   digest?: string;
   status: VersionStatus | null;
   skippable: boolean;
+  releaseLock?: {
+    url: string;
+  };
   imageValidation?: {
     total: number;
     allFound: number;
@@ -119,6 +123,13 @@ export async function GET(request: Request) {
           digest: version.digest,
           status: version.status ?? null,
           skippable: isSkippable(version.status),
+          ...(supportsReleaseLock(version.version)
+            ? {
+                releaseLock: {
+                  url: `/api/v1/versions/${version.version}/release-lock`,
+                },
+              }
+            : {}),
         };
 
         if (includeValidation) {
@@ -151,4 +162,3 @@ export async function GET(request: Request) {
     });
   }
 }
-

--- a/dify-helm-watchdog/src/app/layout.tsx
+++ b/dify-helm-watchdog/src/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {/* 主容器 - 统一控制边距和最大宽度 */}
-          <div className="mx-auto h-screen w-full px-4 py-6 md:px-6 lg:px-8">
+          <div className="mx-auto h-screen w-full px-4 py-3 md:px-6 md:py-4 lg:px-8">
             {children}
           </div>
         </ThemeProvider>

--- a/dify-helm-watchdog/src/components/version-explorer.tsx
+++ b/dify-helm-watchdog/src/components/version-explorer.tsx
@@ -29,6 +29,7 @@ import YAML from "yaml";
 import type {
   CachePayload,
   ImageValidationPayload,
+  ReleaseLockPayload,
   StoredVersion,
 } from "@/lib/types";
 import { CodeBlock } from "@/components/ui/code-block";
@@ -271,6 +272,8 @@ interface ImageTagEntry {
 // Version status from official Dify Helm docs sidebar
 type VersionStatus = "non-skippable" | "archived" | "deprecated";
 
+const RELEASE_LOCK_MIN_VERSION = "3.9.0";
+
 // Manual status overrides, applied on top of the official sidebar. Use this
 // when a version's status isn't (yet) reflected upstream but we want it
 // surfaced in the UI regardless.
@@ -311,6 +314,15 @@ const parseSidebarMd = (content: string): Map<string, VersionStatus> => {
   return map;
 };
 
+const isReleaseLockVersion = (version: string | null | undefined): boolean =>
+  Boolean(version && semver.valid(version) && semver.gte(version, RELEASE_LOCK_MIN_VERSION));
+
+const shortCommit = (commit?: string): string =>
+  commit ? commit.slice(0, 12) : "unknown";
+
+const repoLabel = (repo?: string): string =>
+  repo?.replace(/\.git$/, "").split("/").pop() ?? "source";
+
 export function VersionExplorer({ data }: VersionExplorerProps) {
   const { resolvedTheme } = useTheme();
   const searchParams = useSearchParams();
@@ -342,6 +354,11 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
   const [detailsMode, setDetailsMode] = useState<"markdown" | "html">(
     "markdown",
   );
+  const [releaseLock, setReleaseLock] = useState<ReleaseLockPayload | null>(null);
+  const [releaseLockStatus, setReleaseLockStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
+  const [releaseLockError, setReleaseLockError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadFlag, setReloadFlag] = useState(0);
@@ -540,6 +557,45 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
     return () => controller.abort();
   }, [selectedVersion, detailsReloadKey]);
 
+  useEffect(() => {
+    if (
+      !selectedVersion ||
+      activeArtifact !== "details" ||
+      !isReleaseLockVersion(selectedVersion)
+    ) {
+      setReleaseLock(null);
+      setReleaseLockStatus("idle");
+      setReleaseLockError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setReleaseLock(null);
+    setReleaseLockStatus("loading");
+    setReleaseLockError(null);
+
+    fetch(`/api/v1/versions/${selectedVersion}/release-lock`, {
+      signal: controller.signal,
+    })
+      .then((response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json() as Promise<ReleaseLockPayload>;
+      })
+      .then((payload) => {
+        setReleaseLock(payload);
+        setReleaseLockStatus("success");
+      })
+      .catch((thrown) => {
+        if (thrown instanceof Error && thrown.name === "AbortError") return;
+        setReleaseLock(null);
+        setReleaseLockStatus("error");
+        setReleaseLockError("Failed to load release sources.");
+      });
+
+    return () => controller.abort();
+  }, [selectedVersion, activeArtifact]);
+
   // Wizard handlers
   const handleOpenWizard = useCallback(() => {
     setWizardOpen(true);
@@ -629,7 +685,7 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
 
         const [valuesText, imagesText, validationText] = await Promise.all([
           shouldFetchValues || isReloading
-            ? fetch(version.values.url).then((response) => {
+            ? fetch(`/api/v1/versions/${version.version}/values`).then((response) => {
               if (!response.ok) {
                 throw new Error("Failed to download cached YAML artifacts");
               }
@@ -637,7 +693,7 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
             })
             : Promise.resolve(version.values.inline ?? ""),
           shouldFetchImages || isReloading
-            ? fetch(version.images.url).then((response) => {
+            ? fetch(`/api/v1/versions/${version.version}/images?format=yaml`).then((response) => {
               if (!response.ok) {
                 throw new Error("Failed to download cached YAML artifacts");
               }
@@ -645,7 +701,7 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
             })
             : Promise.resolve(version.images.inline ?? ""),
           shouldFetchValidation
-            ? fetch(validationAsset!.url).then((response) => {
+            ? fetch(`/api/v1/versions/${version.version}/validation`).then((response) => {
               if (!response.ok) {
                 throw new Error("Failed to download image validation payload");
               }
@@ -775,11 +831,14 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
   );
 
   const loadVersionArtifacts = async (version: StoredVersion) => {
-    const resolveAsset = async (asset: StoredVersion["values"]) => {
+    const resolveAsset = async (
+      asset: StoredVersion["values"],
+      url: string,
+    ) => {
       if (typeof asset.inline === "string") {
         return asset.inline;
       }
-      const response = await fetch(asset.url);
+      const response = await fetch(url);
       if (!response.ok) {
         throw new Error("Failed to download cached YAML artifacts");
       }
@@ -787,8 +846,11 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
     };
 
     const [valuesText, imagesText] = await Promise.all([
-      resolveAsset(version.values),
-      resolveAsset(version.images),
+      resolveAsset(version.values, `/api/v1/versions/${version.version}/values`),
+      resolveAsset(
+        version.images,
+        `/api/v1/versions/${version.version}/images?format=yaml`,
+      ),
     ]);
 
     return {
@@ -892,101 +954,179 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
     diffActiveTabId === "images" ? diffImagesContent : diffValuesContent;
 
   const lastSync = formatDateParts(data?.updateTime);
+  const showReleaseSources = isReleaseLockVersion(selectedVersion);
+  const releaseSourcesPanel = showReleaseSources ? (
+    <section className="shrink-0 rounded-xl border border-border bg-card/40 px-3 py-2">
+      <div className="custom-scrollbar flex items-stretch gap-2 overflow-x-auto">
+        <div className="flex min-w-[168px] shrink-0 flex-col justify-center gap-1 border-r border-border pr-3">
+          <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            <FileJson className="h-3.5 w-3.5" />
+            Release sources
+          </span>
+          <div className="flex items-center gap-1.5">
+            <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-xs text-foreground">
+              v{releaseLock?.version ?? selectedVersion}
+            </span>
+            {releaseLock?.releaseTrack ? (
+              <span className="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[#1B4DFF] dark:bg-blue-950 dark:text-blue-400">
+                {releaseLock.releaseTrack}
+              </span>
+            ) : null}
+            {typeof releaseLock?.componentCount === "number" ? (
+              <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
+                {releaseLock.componentCount} components
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        {releaseLock ? (
+          releaseLock.sources.map((source) => (
+            <div
+              key={source.id}
+              className="flex min-w-[210px] shrink-0 flex-col justify-center rounded-lg border border-border bg-background/70 px-3 py-2"
+            >
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <span className="truncate text-xs font-semibold text-foreground">
+                  {source.id}
+                </span>
+                {source.refType ? (
+                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+                    {source.refType}
+                  </span>
+                ) : null}
+                {releaseLock.componentsBySource?.[source.id] ? (
+                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                    {releaseLock.componentsBySource[source.id]}
+                  </span>
+                ) : null}
+              </div>
+              <div
+                className="mt-1 truncate font-mono text-[11px] text-muted-foreground"
+                title={source.ref}
+              >
+                {repoLabel(source.repo)} · {source.ref ?? "unknown ref"}
+              </div>
+              <div
+                className="mt-1 truncate font-mono text-[11px] text-primary"
+                title={source.commit}
+              >
+                {shortCommit(source.commit)}
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="flex min-h-[58px] items-center gap-2 text-sm text-muted-foreground">
+            {releaseLockStatus === "loading" ? (
+              <Loader2 className="h-4 w-4 animate-spin text-primary" />
+            ) : (
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+            )}
+            <span>
+              {releaseLockStatus === "loading"
+                ? "Loading release sources..."
+                : releaseLockError ?? "Release lock not synced yet."}
+            </span>
+          </div>
+        )}
+      </div>
+    </section>
+  ) : null;
 
   return (
-    <div className="flex h-full w-full flex-col gap-4 overflow-hidden">
-      <header className="flex shrink-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-        <div className="mt-[17px] ml-[17px] flex-1">
+    <div className="flex h-full w-full flex-col gap-3 overflow-hidden">
+      <header className="flex shrink-0 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex-1">
           <BrandLockup />
         </div>
         <div className="flex shrink-0 flex-wrap items-stretch justify-end gap-2">
           <button
             type="button"
             onClick={() => setLogsModalOpen(true)}
-            className="group flex min-h-[64px] items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 transition-colors hover:bg-accent/10"
+            className="group flex min-h-[52px] items-center justify-between gap-2 rounded-xl border border-border bg-card px-3 py-2 transition-colors hover:bg-accent/10"
           >
             <div className="flex flex-col items-start leading-tight">
               <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-widest text-muted-foreground">
                 <CalendarClock className="h-3.5 w-3.5 shrink-0" />
                 Last sync
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap text-left">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap text-left">
                 {lastSync.date}
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap text-left">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap text-left">
                 {lastSync.time || "\u00A0"}
               </span>
             </div>
-            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
-              <ScrollText className="h-5 w-5" />
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
+              <ScrollText className="h-4 w-4" />
             </span>
           </button>
 
           <Link
             href="/swagger"
-            className="group flex min-h-[64px] items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 transition-colors hover:bg-accent/10"
+            className="group flex min-h-[52px] items-center justify-between gap-2 rounded-xl border border-border bg-card px-3 py-2 transition-colors hover:bg-accent/10"
           >
             <div className="flex flex-col leading-tight">
               <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-widest text-muted-foreground">
                 <BookOpenText className="h-3.5 w-3.5 shrink-0" />
                 Docs
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap">
                 Swagger
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap">
                 UI
               </span>
             </div>
-            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
-              <ArrowUpRight className="h-5 w-5" />
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
+              <ArrowUpRight className="h-4 w-4" />
             </span>
           </Link>
 
           <Link
             href="/openapi.json"
-            className="group flex min-h-[64px] items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 transition-colors hover:bg-accent/10"
+            className="group flex min-h-[52px] items-center justify-between gap-2 rounded-xl border border-border bg-card px-3 py-2 transition-colors hover:bg-accent/10"
           >
             <div className="flex flex-col leading-tight">
               <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-widest text-muted-foreground">
                 <FileJson className="h-3.5 w-3.5 shrink-0" />
                 Spec
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap">
                 OpenAPI
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap">
                 JSON
               </span>
             </div>
-            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
-              <ArrowUpRight className="h-5 w-5" />
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
+              <ArrowUpRight className="h-4 w-4" />
             </span>
           </Link>
 
           <button
             type="button"
             onClick={() => setMcpModalOpen(true)}
-            className="group flex min-h-[64px] items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 transition-colors hover:bg-accent/10"
+            className="group flex min-h-[52px] items-center justify-between gap-2 rounded-xl border border-border bg-card px-3 py-2 transition-colors hover:bg-accent/10"
           >
             <div className="flex flex-col leading-tight text-left">
               <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-widest text-muted-foreground">
                 <Settings2 className="h-3.5 w-3.5 shrink-0" />
                 Connect
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap">
                 MCP
               </span>
-              <span className="text-xs font-medium text-foreground whitespace-nowrap">
+              <span className="text-[11px] font-medium text-foreground whitespace-nowrap">
                 Server
               </span>
             </div>
-            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
-              <Copy className="h-5 w-5" />
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors group-hover:bg-accent group-hover:text-foreground">
+              <Copy className="h-4 w-4" />
             </span>
           </button>
 
-          <div className="flex min-h-[64px] items-center justify-center rounded-xl border border-border bg-card px-3 py-3">
+          <div className="flex min-h-[52px] items-center justify-center rounded-xl border border-border bg-card px-2 py-2">
             <ThemeToggle />
           </div>
         </div>
@@ -1360,17 +1500,20 @@ export function VersionExplorer({ data }: VersionExplorerProps) {
                   />
                 ) : activeTab.type === "markdown" ? (
                   detailsStatus === "success" ? (
-                    detailsMode === "html" ? (
-                      <div
-                        className="ee-release-notes custom-scrollbar h-full w-full overflow-auto rounded-2xl border border-border bg-card/30 px-2 py-4"
-                        dangerouslySetInnerHTML={{ __html: detailsHtml }}
-                      />
-                    ) : (
-                      <MarkdownRenderer
-                        content={detailsContent}
-                        className="h-full w-full"
-                      />
-                    )
+                    <div className="flex h-full min-h-0 flex-col gap-3">
+                      {releaseSourcesPanel}
+                      {detailsMode === "html" ? (
+                        <div
+                          className="ee-release-notes custom-scrollbar min-h-0 flex-1 overflow-auto rounded-2xl border border-border bg-card/30 px-2 py-4"
+                          dangerouslySetInnerHTML={{ __html: detailsHtml }}
+                        />
+                      ) : (
+                        <MarkdownRenderer
+                          content={detailsContent}
+                          className="min-h-0 flex-1"
+                        />
+                      )}
+                    </div>
                   ) : detailsStatus === "loading" || detailsStatus === "idle" ? (
                     <div className="flex h-full items-center justify-center rounded-2xl border border-border bg-card/30">
                       <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/dify-helm-watchdog/src/lib/mcp/tools.ts
+++ b/dify-helm-watchdog/src/lib/mcp/tools.ts
@@ -8,6 +8,7 @@ import {
   ReleaseNotesError,
   fetchReleaseNotesAsMarkdown,
 } from "@/lib/release-notes";
+import { loadReleaseLock, supportsReleaseLock } from "@/lib/release-locks";
 import type { ImageValidationRecord, StoredVersion } from "@/lib/types";
 import { isSkippable } from "@/lib/version-status";
 import { countValidationStatuses, normalizeValidationPayload } from "@/lib/validation";
@@ -23,7 +24,7 @@ export const TOOLS: McpToolDefinition[] = [
   {
     name: "list_versions",
     description:
-      "Lists all available Dify Helm chart versions with optional validation statistics. Returns version numbers, app versions, creation times, and aggregated image validation counts.",
+      "Lists all available Dify Helm chart versions with optional validation statistics. Returns version numbers, app versions, creation times, aggregated image validation counts, and release-lock URLs for EE versions that support source refs.",
     inputSchema: {
       type: "object",
       properties: {
@@ -47,7 +48,7 @@ export const TOOLS: McpToolDefinition[] = [
   {
     name: "get_version_details",
     description:
-      "Returns detailed metadata for a specific Helm chart version, including chart URL, digest, and asset locations for values.yaml, images, and validation data.",
+      "Returns detailed metadata for a specific Helm chart version, including chart URL, digest, asset locations, and parsed release-lock source refs when available.",
     inputSchema: {
       type: "object",
       properties: {
@@ -186,6 +187,13 @@ const listVersions = async (
         digest: version.digest,
         status: version.status ?? null,
         skippable: isSkippable(version.status),
+        ...(supportsReleaseLock(version.version)
+          ? {
+              releaseLock: {
+                url: `/api/v1/versions/${version.version}/release-lock`,
+              },
+            }
+          : {}),
       };
 
       if (includeValidation && version.imageValidation) {
@@ -259,6 +267,13 @@ const getVersionDetails = async (
   }
 
   const { entry } = result;
+  let releaseLock = null;
+  try {
+    releaseLock = await loadReleaseLock(version);
+  } catch {
+    releaseLock = null;
+  }
+
   return jsonResult({
     version: entry.version,
     appVersion: entry.appVersion ?? null,
@@ -292,10 +307,14 @@ const getVersionDetails = async (
       self: `/api/v1/versions/${version}`,
       images: `/api/v1/versions/${version}/images`,
       values: `/api/v1/versions/${version}/values`,
+      ...(supportsReleaseLock(version)
+        ? { releaseLock: `/api/v1/versions/${version}/release-lock` }
+        : {}),
       ...(entry.imageValidation
         ? { validation: `/api/v1/versions/${version}/validation` }
         : {}),
     },
+    releaseLock,
   });
 };
 
@@ -473,4 +492,3 @@ export const executeTool = async (
       return errorResult(`Unknown tool: ${name}`);
   }
 };
-

--- a/dify-helm-watchdog/src/lib/release-locks.ts
+++ b/dify-helm-watchdog/src/lib/release-locks.ts
@@ -1,0 +1,87 @@
+import semver from "semver";
+import YAML from "yaml";
+import type { ReleaseLockPayload } from "@/lib/types";
+import { STORAGE_PREFIX } from "@/constants/helm";
+
+const MIN_RELEASE_LOCK_VERSION = "3.9.0";
+const DEFAULT_RELEASE_LOCKS_BASE_URL =
+  "https://dify-watchdog-blobs.langgenius.app/helm-watchdog/release-locks";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const supportsReleaseLock = (version: string): boolean =>
+  Boolean(semver.valid(version) && semver.gte(version, MIN_RELEASE_LOCK_VERSION));
+
+const releaseLocksBaseUrl = (): string => {
+  if (process.env.RELEASE_LOCKS_PUBLIC_BASE_URL) {
+    return process.env.RELEASE_LOCKS_PUBLIC_BASE_URL.replace(/\/$/, "");
+  }
+  if (process.env.R2_PUBLIC_BASE_URL) {
+    return `${process.env.R2_PUBLIC_BASE_URL.replace(/\/$/, "")}/${STORAGE_PREFIX}/release-locks`;
+  }
+  return DEFAULT_RELEASE_LOCKS_BASE_URL;
+};
+
+const releaseLockUrlFor = (version: string): string | null => {
+  if (!supportsReleaseLock(version)) return null;
+  return `${releaseLocksBaseUrl()}/${version}.yaml`;
+};
+
+const parseReleaseLockPayload = (raw: string): ReleaseLockPayload => {
+  const parsed = YAML.parse(raw);
+  if (!isRecord(parsed)) {
+    throw new Error("Invalid release lock payload");
+  }
+
+  const sources = Array.isArray(parsed.sources)
+    ? parsed.sources
+        .filter(isRecord)
+        .map((source) => ({
+          id: typeof source.id === "string" ? source.id : "",
+          repo: typeof source.repo === "string" ? source.repo : undefined,
+          ref: typeof source.ref === "string" ? source.ref : undefined,
+          refType: typeof source.ref_type === "string" ? source.ref_type : undefined,
+          commit: typeof source.commit === "string" ? source.commit : undefined,
+        }))
+        .filter((source) => source.id)
+    : [];
+  const components = Array.isArray(parsed.components)
+    ? parsed.components.filter(isRecord)
+    : [];
+  const componentsBySource = components.reduce<Record<string, number>>(
+    (acc, component) => {
+      if (typeof component.source !== "string") return acc;
+      acc[component.source] = (acc[component.source] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+
+  return {
+    version:
+      typeof parsed.version === "string" || typeof parsed.version === "number"
+        ? String(parsed.version)
+        : undefined,
+    releaseTrack:
+      typeof parsed.releaseTrack === "string" ? parsed.releaseTrack : undefined,
+    componentCount: components.length,
+    componentsBySource,
+    sources,
+  };
+};
+
+export const loadReleaseLock = async (
+  version: string,
+): Promise<ReleaseLockPayload | null> => {
+  const url = releaseLockUrlFor(version);
+  if (!url) return null;
+
+  const response = await fetch(url, {
+    next: { revalidate: 3600 },
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+  return parseReleaseLockPayload(await response.text());
+};

--- a/dify-helm-watchdog/src/lib/types.ts
+++ b/dify-helm-watchdog/src/lib/types.ts
@@ -34,6 +34,22 @@ export interface CachePayload {
   versions: StoredVersion[];
 }
 
+export interface ReleaseLockSource {
+  id: string;
+  repo?: string;
+  ref?: string;
+  refType?: string;
+  commit?: string;
+}
+
+export interface ReleaseLockPayload {
+  version?: string;
+  releaseTrack?: string;
+  componentCount?: number;
+  componentsBySource?: Record<string, number>;
+  sources: ReleaseLockSource[];
+}
+
 export type ImageVariantName = "ORIGINAL" | "AMD64" | "ARM64";
 
 export type ImageVariantStatus = "FOUND" | "MISSING" | "ERROR";


### PR DESCRIPTION
## Summary
- add a script to incrementally sync `versions.lock.yaml` from `langgenius/ee-release` tags into R2
- load synced release-lock YAML server-side and pass parsed source refs into the UI
- render release sources under the Details tab and keep Values/Image Versions focused on artifacts
- compact the top toolbar to reduce vertical space

## Validation
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint src/app/layout.tsx src/app/page.tsx src/components/version-explorer.tsx src/lib/types.ts src/lib/release-locks.ts`

## Notes
- Local credential file `scripts/.sync-ee-release-locks.env` is ignored by git.
- The browser no longer fetches release-lock YAML directly; the page receives parsed data from the server.
